### PR TITLE
image upload

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,1 @@
-GRID_URL=https://media.test.dev-gutools.co.uk
+GRID_DOMAIN=media.test.dev-gutools.co.uk

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-GRID_URL=https://media.gutools.co.uk
+GRID_DOMAIN=media.gutools.co.uk

--- a/src/config.js
+++ b/src/config.js
@@ -29,5 +29,27 @@ export default {
     yellow: '#ffe500',
     grey: '#ececec',
     custom: 'custom'
+  },
+  upload: {
+    labels: [
+      'edition-cover-card'
+    ],
+    collections: [
+      'iPad Daily Edition'
+    ],
+    metadataToCopy: [
+      'credit',
+      'description',
+      'dateTaken',
+      'byline',
+      'bylineTitle',
+      'title',
+      'copyrightNotice',
+      'copyright',
+      'suppliersReference',
+      'source',
+      'city',
+      'country'
+    ]
   }
 };

--- a/src/grid/modal.js
+++ b/src/grid/modal.js
@@ -2,8 +2,8 @@ import templateString from './template.html';
 import './modal.css';
 
 class GridModal {
-  constructor({gridUrl, triggerEl, targetInput}) {
-    this.gridUrl = gridUrl;
+  constructor({gridDomain, triggerEl, targetInput}) {
+    this.gridUrl = `https://${gridDomain}`;
     this.triggerEl = triggerEl;
     this.targetInput = targetInput;
 
@@ -38,6 +38,10 @@ class GridModal {
     document.body.removeChild(document.querySelector('.modal'));
   }
 
+  getApiResponse() {
+    return this.apiResponse;
+  }
+
   _isValidMessage(data) {
     return (
       data
@@ -52,6 +56,7 @@ class GridModal {
     if (event.origin !== this.gridUrl || !this._isValidMessage(event.data)) {
       return;
     }
+    this.apiResponse = event.data.image;
     this.imageId = event.data.image.data.id;
     this.targetInput.value = event.data.crop.data.master.secureUrl;
     this.targetInput.parentElement.dispatchEvent(new Event('input'));

--- a/src/grid/upload.js
+++ b/src/grid/upload.js
@@ -1,0 +1,89 @@
+import Config from '../config';
+
+const TIMEOUT = 1500;
+
+function wait(fn) {
+  return new Promise(resolve => setTimeout(_ => resolve(fn()), TIMEOUT));
+}
+
+function uploadImage({gridDomain, image}) {
+  return fetch(`https://loader.${gridDomain}/images`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/octet-stream'
+    },
+    body: image
+  })
+  .then(res => res.json())
+  .then(res => wait( // wait for media-api to index the new image
+    () => fetch(res.uri, { credentials: 'include' }).then(res => res.json())
+  ));
+}
+
+function editImage({endpoint, method, body}) {
+  return fetch(endpoint, {
+    method: method,
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({data: body})
+  }).then(res => res.json());
+}
+
+function addLabels({apiResponse}) {
+  return editImage({
+    endpoint: apiResponse.data.userMetadata.data.labels.uri,
+    method: 'POST',
+    body: Config.upload.labels
+  });
+}
+
+function copyMetadata({apiResponse, originalImage}) {
+  const originalMetadata = originalImage.data.metadata;
+  const copiedMetadata = Object.entries(originalMetadata).reduce((acc, [key, value]) => {
+    return Config.upload.metadataToCopy.includes(key) ? {...acc, [key]: value} : acc;
+  }, {});
+
+  return editImage({
+    endpoint: apiResponse.data.userMetadata.data.metadata.uri,
+    method: 'PUT',
+    body: copiedMetadata
+  });
+}
+
+function copyUsageRights({apiResponse, originalImage}) {
+  const originalUsageRights = originalImage.data.usageRights;
+
+  if(!originalUsageRights) {
+    return Promise.resolve();
+  }
+
+  return editImage({
+    endpoint: apiResponse.data.userMetadata.data.usageRights.uri,
+    method: 'PUT',
+    body: originalUsageRights
+  });
+}
+
+function addCollections({apiResponse}) {
+  const endpoint = apiResponse.actions.find(action => action.name === 'add-collection').href;
+
+  return editImage({
+    endpoint,
+    method: 'POST',
+    body: Config.upload.collections
+  })
+}
+
+function upload({gridDomain, image, originalImage}) {
+  return uploadImage({gridDomain, image}).then(apiResponse => Promise.all([
+    addLabels({apiResponse}),
+    copyMetadata({apiResponse, originalImage}),
+    copyUsageRights({apiResponse, originalImage}),
+    addCollections({apiResponse})
+  ]));
+}
+
+export default upload;

--- a/src/index.html
+++ b/src/index.html
@@ -14,6 +14,7 @@
       create cards for the Editions app
     </div>
     <div>
+      <button id="upload" disabled>Upload</button>
       <a id="download" download>Download</a>
     </div>
   </header>

--- a/src/main.css
+++ b/src/main.css
@@ -316,7 +316,7 @@ a {
 a:not([href]),
 button:disabled {
   cursor: not-allowed;
-  opacity: 0.5;
+  opacity: 0.8;
 }
 
 a[href]:hover,

--- a/src/main.css
+++ b/src/main.css
@@ -305,6 +305,7 @@ button {
   color: #fff;
   font-size: 24px;
   font-family: "Guardian Titlepiece";
+  border: none;
 }
 
 a {
@@ -315,7 +316,7 @@ a {
 a:not([href]),
 button:disabled {
   cursor: not-allowed;
-  opacity: 0.2;
+  opacity: 0.5;
 }
 
 a[href]:hover,

--- a/src/main.js
+++ b/src/main.js
@@ -3,11 +3,16 @@ import CanvasCard from './canvas';
 import Config from './config';
 
 const form = document.querySelector('.card-builder-form');
-const downloadLink = document.querySelector('#download');
+const downloadLink = document.getElementById('download');
 const customColourInput = document.getElementById('customColour');
 const destination = document.querySelector(".card-builder-right");
+const uploadButton = document.getElementById('upload');
 
 const canvasCard = new CanvasCard();
+
+uploadButton.addEventListener('click', _ => {
+  console.log('uploading image to Grid');
+});
 
 form.addEventListener('input', e => {
   const formData = new FormData(form);
@@ -31,6 +36,9 @@ form.addEventListener('input', e => {
   customColourInput.style.display = isCustomColour ? 'inline-block' : 'none';
   const colourCode = isCustomColour ? customColour : Config.colours[colour];
 
+  downloadLink.removeAttribute('href');
+  uploadButton.disabled = true;
+
   canvasCard.draw({
     device,
     imageUrl,
@@ -49,7 +57,8 @@ form.addEventListener('input', e => {
     destination.appendChild(canvas);
 
     const image = canvas.toDataURL("image/png");
-    downloadLink.href = image;
+    downloadLink.setAttribute('href', image);
+    uploadButton.disabled = false;
   }).catch(e => console.error(e));
 });
 


### PR DESCRIPTION
Add ability to upload generated image to Grid.

Once uploaded:
- Wait 1.5s for media-api to index image
- Add labels
- Copy metadata from original image over
- Copy usage rights from original image over
- Add collections

Requires https://github.com/guardian/grid/pull/2652.