### PR TITLE
only show link to uploaded Grid image after upload

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -13,7 +13,7 @@
         create cards for the Editions app
       </div>
       <div>
-        <a id="gridLink" target="_blank" rel="noopener noreferrer"></a>
+        <a id="gridLink" target="_blank" rel="noopener noreferrer">🖼 Grid</a>
         <button id="upload" disabled>Upload</button>
         <button id="download" download>Download</button>
       </div>

--- a/src/main.css
+++ b/src/main.css
@@ -313,7 +313,10 @@ a {
   text-decoration: none;
 }
 
-a:not([href]),
+a:not([href]) {
+  display: none;
+}
+
 button:disabled {
   cursor: not-allowed;
   opacity: 0.8;

--- a/src/main.js
+++ b/src/main.js
@@ -44,7 +44,6 @@ uploadButton.addEventListener("click", _ => {
         const imageUrl = apiResponse.links.find(({ rel }) => rel === "ui:image")
           .href;
         gridLink.href = imageUrl;
-        gridLink.innerText = "🖼 Grid";
         uploadButton.innerText = "Uploaded";
       })
       .catch(error => {
@@ -89,6 +88,7 @@ const draw = () => {
 
   uploadButton.disabled = true;
   downloadButton.disabled = true;
+  gridLink.removeAttribute("href");
 
   canvasCard
     .draw({


### PR DESCRIPTION
This app can upload an image to Grid. Once it has uploaded, we display a link to the image. If we change the content of the canvas, we should remove the link to the image as it doesn't represent the same data anymore.

# Initial Load
**before**
![image](https://user-images.githubusercontent.com/836140/71241685-207b1500-2304-11ea-9032-fac693098093.png)

**after**
![image](https://user-images.githubusercontent.com/836140/71241695-2670f600-2304-11ea-9588-3485274d28c4.png)

# After Upload
**before**
![image](https://user-images.githubusercontent.com/836140/71241745-456f8800-2304-11ea-8fd2-75e8866b7d00.png)

**after**
![image](https://user-images.githubusercontent.com/836140/71241789-62a45680-2304-11ea-9894-4cab2631611e.png)

# Making an edit after upload
**before**
![image](https://user-images.githubusercontent.com/836140/71241846-7cde3480-2304-11ea-851a-17490eeb72df.png)

**after**
![image](https://user-images.githubusercontent.com/836140/71241855-849dd900-2304-11ea-892b-039c382ad112.png)
