### PR TITLE
allow headline to use soft and hard returns

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -25,13 +25,11 @@
           <input id="imageUrl" type="hidden" name="imageUrl" />
 
           <label for="headline">Headline</label>
-          <input
+          <textarea
             id="headline"
             name="headline"
-            class="input-headline"
-            type="text"
             placeholder="headline..."
-          />
+          ></textarea>
 
           <fieldset>
             <legend>Headline Size</legend>


### PR DESCRIPTION
## What does this change?
Converts the input into a text area to allow line returns.

## How can we measure success?
Headlines can wrap multiple lines without the need to enter whitespace.

## Images
**Before**
![before](https://user-images.githubusercontent.com/836140/84989652-e74d2180-b13b-11ea-887d-6e0ecb99949e.gif)

**After**
![after](https://user-images.githubusercontent.com/836140/84989672-efa55c80-b13b-11ea-9ad5-d3584af0996d.gif)
