### PR TITLE
Add swatches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -862,6 +862,11 @@
         "to-fast-properties": "2.0.0"
       }
     },
+    "@guardian/src-foundations": {
+      "version": "1.5.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@guardian/src-foundations/-/src-foundations-1.5.0-rc.0.tgz",
+      "integrity": "sha512-/1v2GRp9yXIwH8ZR0M/kBfIv8GVtGg36oACDgktGAQIPSWWtteYkiBoUge/Sqsyw2MIR5YVcifRs2YycEQiZ8A=="
+    },
     "@iarna/toml": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/guardian/editions-card-builder#readme",
   "dependencies": {
+    "@guardian/src-foundations": "^1.5.0-rc.0",
     "debounce": "^1.2.0",
     "downloadjs": "^1.4.7"
   },

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,5 @@
+import { labs, lifestyle, culture, sport, opinion, news, brand, brandAlt, neutral, specialReport } from '@guardian/src-foundations/palette'
+
 export default {
   dimensions: {
     mobile: [525, 810],
@@ -59,22 +61,24 @@ export default {
       }
     }
   },
-  // colours taken directly from: https://design.theguardian.com/#colour-palette-4
   swatches: {
-    uk: {
-      white: "#eeeeee",
+    simple: {
+      white: "#ffffff",
       red: "#c70000",     // news main
       blue: "#052962",    // brand main
       yellow: "#ffe500",  // highlight main
-      grey: "#ededed",    // neutral (brightness 93)
+      grey: "#ededed"     // neutral (brightness 93)
     },
-    australia: {
-      white: "#ffffff",
-      blue: "#041F4A",    // brand dark
-      ochre: "#A1845C",   // cuture main
-      purple: "#7D0068",  // lifestyle dark
-      orange: "#E05E00"   // opinion main
-    }
+    brand: (({ dark, main, pastel }) => ({ dark, main, pastel }))(brand),
+    highlight: (({ dark, main }) => ({ dark, main }))(brandAlt),
+    news: (({ dark, main, bright, pastel, faded }) => ({ dark, main, bright, pastel, faded }))(news),
+    opinion: (({ dark, main, bright, pastel, faded }) => ({ dark, main, bright, pastel, faded }))(opinion),
+    sport: (({ dark, main, bright, pastel, faded }) => ({ dark, main, bright, pastel, faded }))(sport),
+    culture: (({ dark, main, bright, pastel, faded }) => ({ dark, main, bright, pastel, faded }))(culture),
+    lifestyle: (({ dark, main, bright, pastel, faded }) => ({ dark, main, bright, pastel, faded }))(lifestyle),
+    labs: (({ dark, main }) => ({ dark, main }))(labs),
+    neutral: { main: neutral["60"] },
+    special: { main: specialReport["100"] }
   },
   upload: {
     labels: ["edition-cover-card"],

--- a/src/config.js
+++ b/src/config.js
@@ -59,13 +59,21 @@ export default {
       }
     }
   },
-  colours: {
-    white: "#eeeeee",
-    red: "#c70000",
-    blue: "#052962",
-    yellow: "#ffe500",
-    grey: "#ececec",
-    custom: "custom"
+  swatches: {
+    uk: {
+      white: "#eeeeee",
+      red: "#c70000",
+      blue: "#052962",
+      yellow: "#ffe500",
+      grey: "#ececec"
+    },
+    australia: {
+      white: "#ffffff",
+      blue: "#041F4A",
+      ochre: "#A1845C",
+      purple: "#7D0068",
+      orange: "#E05E00"
+    }
   },
   upload: {
     labels: ["edition-cover-card"],

--- a/src/config.js
+++ b/src/config.js
@@ -59,20 +59,21 @@ export default {
       }
     }
   },
+  // colours taken directly from: https://design.theguardian.com/#colour-palette-4
   swatches: {
     uk: {
       white: "#eeeeee",
-      red: "#c70000",
-      blue: "#052962",
-      yellow: "#ffe500",
-      grey: "#ececec"
+      red: "#c70000",     // news main
+      blue: "#052962",    // brand main
+      yellow: "#ffe500",  // highlight main
+      grey: "#ededed",    // neutral (brightness 93)
     },
     australia: {
       white: "#ffffff",
-      blue: "#041F4A",
-      ochre: "#A1845C",
-      purple: "#7D0068",
-      orange: "#E05E00"
+      blue: "#041F4A",    // brand dark
+      ochre: "#A1845C",   // cuture main
+      purple: "#7D0068",  // lifestyle dark
+      orange: "#E05E00"   // opinion main
     }
   },
   upload: {

--- a/src/index.html
+++ b/src/index.html
@@ -65,20 +65,82 @@
             <legend>Swatch</legend>
             <input
               type="radio"
-              id="uk"
+              id="simple"
               name="swatch"
-              value="uk"
+              value="simple"
               checked
             />
-            <label for="uk">UK</label>
-
+            <label for="simple">Simple</label>
             <input
               type="radio"
-              id="au"
+              id="brand"
               name="swatch"
-              value="australia"
+              value="brand"
             />
-            <label for="au">Australia</label>
+            <label for="brand">Brand</label>
+            <input
+              type="radio"
+              id="highlight"
+              name="swatch"
+              value="highlight"
+            />
+            <label for="highlight">Highlight</label>
+            <input
+              type="radio"
+              id="news"
+              name="swatch"
+              value="news"
+            />
+            <label for="news">News</label>
+            <input
+              type="radio"
+              id="opinion"
+              name="swatch"
+              value="opinion"
+            />
+            <label for="opinion">Opinion</label>
+            <input
+              type="radio"
+              id="labs"
+              name="swatch"
+              value="labs"
+            />
+            <label for="labs">Labs</label>
+            <input
+              type="radio"
+              id="lifestyle"
+              name="swatch"
+              value="lifestyle"
+            />
+            <label for="lifestyle">Lifestyle</label>
+            <input
+              type="radio"
+              id="sport"
+              name="swatch"
+              value="sport"
+            />
+            <label for="sport">Sport</label>
+            <input
+              type="radio"
+              id="culture"
+              name="swatch"
+              value="culture"
+            />
+            <label for="culture">Culture</label>
+            <input
+              type="radio"
+              id="neutral"
+              name="swatch"
+              value="neutral"
+            />
+            <label for="neutral">Neutral</label>
+            <input
+              type="radio"
+              id="special"
+              name="swatch"
+              value="special"
+            />
+            <label for="special">Special</label>
           </fieldset>
 
           <fieldset class="colour">
@@ -100,6 +162,7 @@
                 type="text"
                 value="hotpink"
               />
+
             </div>
           </fieldset>
 

--- a/src/index.html
+++ b/src/index.html
@@ -61,35 +61,31 @@
             <label for="headlineLarge">Large</label>
           </fieldset>
 
-          <fieldset class="colour">
-            <legend>Colour</legend>
-
+          <fieldset class="swatch">
+            <legend>Swatch</legend>
             <input
               type="radio"
-              id="colourWhite"
-              name="colour"
-              value="white"
+              id="uk"
+              name="swatch"
+              value="uk"
               checked
             />
-            <label for="colourWhite">White</label>
-
-            <input type="radio" id="colourRed" name="colour" value="red" />
-            <label for="colourRed">Red</label>
-
-            <input type="radio" id="colourBlue" name="colour" value="blue" />
-            <label for="colourBlue">Blue</label>
+            <label for="uk">UK</label>
 
             <input
               type="radio"
-              id="colourYellow"
-              name="colour"
-              value="yellow"
+              id="au"
+              name="swatch"
+              value="australia"
             />
-            <label for="colourYellow">Yellow</label>
+            <label for="au">Australia</label>
+          </fieldset>
 
-            <input type="radio" id="colourGrey" name="colour" value="grey" />
-            <label for="colourGrey">Grey</label>
+          <fieldset class="colour">
+            <legend>Colour</legend>
+            <div class="coloursBySwatch">
 
+            </div>
             <div>
               <input
                 type="radio"

--- a/src/main.css
+++ b/src/main.css
@@ -205,8 +205,8 @@ header h1 {
 }
 
 .card-builder-left {
-  min-width: 400px;
-  width: 400px;
+  min-width: 375px;
+  width: 375px;
   background-color: var(--blueish);
 }
 

--- a/src/main.css
+++ b/src/main.css
@@ -205,8 +205,8 @@ header h1 {
 }
 
 .card-builder-left {
-  min-width: 375px;
-  width: 375px;
+  min-width: 400px;
+  width: 400px;
   background-color: var(--blueish);
 }
 
@@ -265,28 +265,6 @@ input[type="radio"] + label {
 input[type="radio"]:checked + label {
   text-decoration: underline;
   font-weight: 600;
-}
-
-.colour label[for="colourWhite"] {
-  background-color: #ffffff;
-}
-
-.colour label[for="colourRed"] {
-  background-color: #c70000;
-  color: #fff;
-}
-
-.colour label[for="colourBlue"] {
-  background-color: #052962;
-  color: #fff;
-}
-
-.colour label[for="colourYellow"] {
-  background-color: #ffe500;
-}
-
-.colour label[for="colourGrey"] {
-  background-color: #ececec;
 }
 
 #customColour {

--- a/src/main.js
+++ b/src/main.js
@@ -88,7 +88,7 @@ function contrastTextColor(hex) {
 
 const addColours = () => {
 
-  var first=true;
+  let first=true;
   for (var swatch in Config.swatches) {
     var coloursBySwatchChild = document.createElement("div")
     coloursBySwatchChild.className="swatchset swatch-" + swatch

--- a/src/main.js
+++ b/src/main.js
@@ -98,11 +98,11 @@ const addColours = () => {
       coloursBySwatchChild.style.display="none"
 
     for (var colourKey in Config.swatches[swatch]) {
-      var colourKeyDisplay = colourKey.charAt(0).toUpperCase() + colourKey.slice(1);
+      const colourKeyDisplay = colourKey.charAt(0).toUpperCase() + colourKey.slice(1);
 
-      var id = "colour-" + colourKey + "-" + swatch
+      const id = "colour-" + colourKey + "-" + swatch
 
-      var colourInputElement = document.createElement("input")
+      const colourInputElement = document.createElement("input")
       colourInputElement.type="radio"
       colourInputElement.id=id
       colourInputElement.name="colour"
@@ -110,7 +110,7 @@ const addColours = () => {
       colourInputElement.checked = first;
       coloursBySwatchChild.appendChild(colourInputElement)
 
-      var colourLabelElement = document.createElement("label")
+      const colourLabelElement = document.createElement("label")
       colourLabelElement.htmlFor=id
       colourLabelElement.textContent = colourKeyDisplay
       colourLabelElement.className="swatchcolour"

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ import debounce from "debounce";
 import download from "downloadjs";
 
 const form = document.querySelector(".card-builder-form");
+const coloursBySwatch = document.querySelector(".coloursBySwatch")
 const downloadButton = document.getElementById("download");
 const customColourInput = document.getElementById("customColour");
 const destination = document.querySelector(".card-builder-right");
@@ -64,6 +65,65 @@ downloadButton.addEventListener("click", _ => {
     download(blob, "image.png", "image/png");
   });
 });
+
+
+function contrastTextColor(hex) {
+    if (hex.indexOf('#') === 0) {
+        hex = hex.slice(1);
+    }
+    // convert 3-digit hex to 6-digits.
+    if (hex.length === 3) {
+        hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+    }
+    if (hex.length !== 6) {
+        throw new Error('Invalid HEX color.');
+    }
+    const brightness =
+      parseInt(hex.slice(0, 2), 16) + parseInt(hex.slice(2, 4), 16) + parseInt(hex.slice(4, 6), 16)
+    if (brightness < 200)
+      return '#ffffff'
+    else
+      return '#000000'
+}
+
+const addColours = () => {
+
+  var first=true;
+  for (var swatch in Config.swatches) {
+    var coloursBySwatchChild = document.createElement("div")
+    coloursBySwatchChild.className="swatchset swatch-" + swatch
+    if (first)
+      coloursBySwatchChild.style.display="inline-block"
+    else
+      coloursBySwatchChild.style.display="none"
+
+    for (var colourKey in Config.swatches[swatch]) {
+      var colourKeyDisplay = colourKey.charAt(0).toUpperCase() + colourKey.slice(1);
+
+      var id = "colour-" + colourKey + "-" + swatch
+
+      var colourInputElement = document.createElement("input")
+      colourInputElement.type="radio"
+      colourInputElement.id=id
+      colourInputElement.name="colour"
+      colourInputElement.value=colourKey
+      colourInputElement.checked = first;
+      coloursBySwatchChild.appendChild(colourInputElement)
+
+      var colourLabelElement = document.createElement("label")
+      colourLabelElement.htmlFor=id
+      colourLabelElement.textContent = colourKeyDisplay
+      colourLabelElement.className="swatchcolour"
+      colourLabelElement.style.backgroundColor=Config.swatches[swatch][colourKey]
+      colourLabelElement.style.color=contrastTextColor(Config.swatches[swatch][colourKey])
+      colourLabelElement.addEventListener("click", debounce(draw, 200));
+      coloursBySwatchChild.appendChild(colourLabelElement)
+      first=false;
+    }
+    coloursBySwatch.appendChild(coloursBySwatchChild)
+  }
+}
+
 const draw = () => {
   const formData = new FormData(form);
 
@@ -73,6 +133,7 @@ const draw = () => {
     headlineSize,
     standfirst,
     standfirstSize,
+    swatch,
     colour,
     customColour,
     position,
@@ -80,11 +141,25 @@ const draw = () => {
     svgHeadline
   } = Object.fromEntries(formData);
 
-  const isCustomColour = colour === Config.colours.custom;
+  var activeSwatchset = document.querySelector(".swatch-" + swatch)
+
+  // If we have just switched swatch, use the first child, otherwise the last value.
+  var activeColour= activeSwatchset.style.display == "none" ? activeSwatchset.firstChild.value : colour
+
+  // Show/hide colour selectors according to chosen swatch
+  if (activeSwatchset.style.display == "none") {
+     // swatch has changed
+    var allColours = document.querySelectorAll(".swatchset")
+    for (let node of allColours) node.style.display="none";
+    activeSwatchset.style.display="inline-block";
+    var activeColourInput = activeSwatchset.firstChild
+    activeColourInput.checked=true
+  }
 
   // show custom colour input if `custom` is selected
+  const isCustomColour = activeColour === "custom";
   customColourInput.style.display = isCustomColour ? "inline-block" : "none";
-  const colourCode = isCustomColour ? customColour : Config.colours[colour];
+  const colourCode = isCustomColour ? customColour : Config.swatches[swatch][activeColour];
 
   uploadButton.disabled = true;
   downloadButton.disabled = true;
@@ -111,6 +186,10 @@ const draw = () => {
       downloadButton.disabled = false;
     })
     .catch(e => console.error(e));
-};
+}
+
+addColours()
 
 form.addEventListener("input", debounce(draw, 200));
+
+draw()

--- a/src/main.js
+++ b/src/main.js
@@ -91,7 +91,7 @@ const addColours = () => {
   let first=true;
   for (let swatch in Config.swatches) {
     var coloursBySwatchChild = document.createElement("div")
-    coloursBySwatchChild.className="swatchset swatch-" + swatch
+    coloursBySwatchChild.className=`swatchset swatch-${swatch}`
     if (first)
       coloursBySwatchChild.style.display="inline-block"
     else

--- a/src/main.js
+++ b/src/main.js
@@ -140,7 +140,6 @@ const draw = () => {
     svgHeadline
   } = Object.fromEntries(formData);
 
-console.log(Object.fromEntries(formData))
   var activeSwatchset = document.querySelector(".swatch-" + swatch)
 
   // If we have just switched swatch, use the first child, otherwise the last value.

--- a/src/main.js
+++ b/src/main.js
@@ -89,7 +89,7 @@ function contrastTextColor(hex) {
 const addColours = () => {
 
   let first=true;
-  for (var swatch in Config.swatches) {
+  for (let swatch in Config.swatches) {
     var coloursBySwatchChild = document.createElement("div")
     coloursBySwatchChild.className="swatchset swatch-" + swatch
     if (first)

--- a/src/main.js
+++ b/src/main.js
@@ -80,7 +80,7 @@ function contrastTextColor(hex) {
     }
     const brightness =
       parseInt(hex.slice(0, 2), 16) + parseInt(hex.slice(2, 4), 16) + parseInt(hex.slice(4, 6), 16)
-    if (brightness < 200)
+    if (brightness < 300)
       return '#ffffff'
     else
       return '#000000'
@@ -116,7 +116,6 @@ const addColours = () => {
       colourLabelElement.className="swatchcolour"
       colourLabelElement.style.backgroundColor=Config.swatches[swatch][colourKey]
       colourLabelElement.style.color=contrastTextColor(Config.swatches[swatch][colourKey])
-      colourLabelElement.addEventListener("click", debounce(draw, 200));
       coloursBySwatchChild.appendChild(colourLabelElement)
       first=false;
     }
@@ -141,6 +140,7 @@ const draw = () => {
     svgHeadline
   } = Object.fromEntries(formData);
 
+console.log(Object.fromEntries(formData))
   var activeSwatchset = document.querySelector(".swatch-" + swatch)
 
   // If we have just switched swatch, use the first child, otherwise the last value.
@@ -191,5 +191,3 @@ const draw = () => {
 addColours()
 
 form.addEventListener("input", debounce(draw, 200));
-
-draw()

--- a/src/main.js
+++ b/src/main.js
@@ -148,7 +148,7 @@ const draw = () => {
   // Show/hide colour selectors according to chosen swatch
   if (activeSwatchset.style.display == "none") {
      // swatch has changed
-    var allColours = document.querySelectorAll(".swatchset")
+    const allColours = document.querySelectorAll(".swatchset")
     for (let node of allColours) node.style.display="none";
     activeSwatchset.style.display="inline-block";
     const activeColourInput = activeSwatchset.firstChild

--- a/src/main.js
+++ b/src/main.js
@@ -90,7 +90,7 @@ const addColours = () => {
 
   let first=true;
   for (let swatch in Config.swatches) {
-    var coloursBySwatchChild = document.createElement("div")
+    const coloursBySwatchChild = document.createElement("div")
     coloursBySwatchChild.className=`swatchset swatch-${swatch}`
     if (first)
       coloursBySwatchChild.style.display="inline-block"

--- a/src/main.js
+++ b/src/main.js
@@ -151,7 +151,7 @@ const draw = () => {
     var allColours = document.querySelectorAll(".swatchset")
     for (let node of allColours) node.style.display="none";
     activeSwatchset.style.display="inline-block";
-    var activeColourInput = activeSwatchset.firstChild
+    const activeColourInput = activeSwatchset.firstChild
     activeColourInput.checked=true
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -143,7 +143,7 @@ const draw = () => {
   var activeSwatchset = document.querySelector(".swatch-" + swatch)
 
   // If we have just switched swatch, use the first child, otherwise the last value.
-  var activeColour= activeSwatchset.style.display == "none" ? activeSwatchset.firstChild.value : colour
+  const activeColour= activeSwatchset.style.display == "none" ? activeSwatchset.firstChild.value : colour
 
   // Show/hide colour selectors according to chosen swatch
   if (activeSwatchset.style.display == "none") {


### PR DESCRIPTION
See https://trello.com/c/lBqlvwYS/1240-support-new-swatches-for-fronts

## What does this change?
It adds swatches, which are groups of colours used by different Editions, eg AU and UK can have different colour schemes.  Colours are easily (triviably) added and altered in config.js

## How can we measure success?
All existing functionality continues, swatches enable different groups of colours to be used.

## Images
Before:
![image](https://user-images.githubusercontent.com/5476326/85037394-39626700-b17d-11ea-9e87-2472942fa06d.png)
After:
![image](https://user-images.githubusercontent.com/5476326/85128893-1772ee00-b22a-11ea-9390-642c3a34aba4.png)
