### PR TITLE
Allow any vertical position for text

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -138,7 +138,7 @@
             <input
               type="radio"
               id="positionTop"
-              name="position"
+              name="positionValue"
               value="0"
               checked
             />
@@ -147,18 +147,35 @@
             <input
               type="radio"
               id="positionMiddle"
-              name="position"
+              name="positionValue"
               value="40"
             />
             <label for="positionMiddle">Middle</label>
-
             <input
               type="radio"
               id="positionBottom"
-              name="position"
+              name="positionValue"
               value="100"
             />
             <label for="positionBottom">Bottom</label>
+            <br/>
+            <div>
+              <input
+                type="radio"
+                id="positionCustom"
+                name="positionValue"
+                value="-1"
+              />
+              <label for="positionCustom">Custom</label>
+              <input
+                id="customPosition"
+                name="customPosition"
+                type="number"
+                value="40"
+                min="1"
+                max="99"
+              />
+            </div>
 
           </fieldset>
 

--- a/src/main.css
+++ b/src/main.css
@@ -294,6 +294,11 @@ input[type="radio"]:checked + label {
   width: 150px;
 }
 
+#customPosition {
+  display: none;
+  width: 150px;
+}
+
 .image-select {
   width: 100%;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ import download from "downloadjs";
 const form = document.querySelector(".card-builder-form");
 const downloadButton = document.getElementById("download");
 const customColourInput = document.getElementById("customColour");
+const customPositionInput = document.getElementById("customPosition");
 const destination = document.querySelector(".card-builder-right");
 const uploadButton = document.getElementById("upload");
 const gridLink = document.getElementById("gridLink");
@@ -75,16 +76,22 @@ const draw = () => {
     standfirstSize,
     colour,
     customColour,
-    position,
+    positionValue,
+    customPosition,
     device,
     svgHeadline
   } = Object.fromEntries(formData);
 
-  const isCustomColour = colour === Config.colours.custom;
 
   // show custom colour input if `custom` is selected
+  const isCustomColour = colour === Config.colours.custom;
   customColourInput.style.display = isCustomColour ? "inline-block" : "none";
   const colourCode = isCustomColour ? customColour : Config.colours[colour];
+
+  // show custom position input if `custom` is selected
+  const isCustomPosition = positionValue === "-1";
+  customPositionInput.style.display = isCustomPosition ? "inline-block" : "none";
+  const position = isCustomPosition ? customPosition : parseInt(positionValue);
 
   uploadButton.disabled = true;
   downloadButton.disabled = true;


### PR DESCRIPTION
## What does this change?
Currently only three positions are available for text: top, middle, and bottom.
This change allows custom position settings, 0-100% of the available range.

## How can we measure success?
Create images with text in an arbitrary location

## Images
![image](https://user-images.githubusercontent.com/5476326/85144612-52355000-b243-11ea-85e6-6b4048347f64.png)
