### PR TITLE
re-order form, push device choice to top

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -24,6 +24,26 @@
           <button type="button" class="image-select">Select image</button>
           <input id="imageUrl" type="hidden" name="imageUrl" />
 
+          <fieldset>
+            <legend>Device</legend>
+            <input
+              type="radio"
+              id="deviceMobile"
+              name="device"
+              value="mobile"
+              checked
+            />
+            <label for="deviceMobile">Mobile</label>
+
+            <input
+              type="radio"
+              id="deviceTablet"
+              name="device"
+              value="tablet"
+            />
+            <label for="deviceTablet">Tablet</label>
+          </fieldset>
+
           <label for="headline">Headline</label>
           <textarea
             id="headline"
@@ -171,26 +191,6 @@
               />
             </div>
 
-          </fieldset>
-
-          <fieldset>
-            <legend>Device</legend>
-            <input
-              type="radio"
-              id="deviceMobile"
-              name="device"
-              value="mobile"
-              checked
-            />
-            <label for="deviceMobile">Mobile</label>
-
-            <input
-              type="radio"
-              id="deviceTablet"
-              name="device"
-              value="tablet"
-            />
-            <label for="deviceTablet">Tablet</label>
           </fieldset>
         </form>
       </div>


### PR DESCRIPTION
## What does this change?
As I understand, the positioning and size of text is determined by how the image appears on the device. Putting this form element first helps keep the form ordered; we progress top to bottom rather than top, bottom, middle.

## How can we measure success?
A more natural progression through the form.

## Images
**Before**
![image](https://user-images.githubusercontent.com/836140/86166960-97903200-bb0d-11ea-8c8a-f67df9139380.png)


**After**
![image](https://user-images.githubusercontent.com/836140/86166927-87785280-bb0d-11ea-9315-9068b1c1d906.png)
