### PR TITLE
perform necessary configuration for the gh-pages module

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Deploy to GitHub Pages
-        run: ./script/cd
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # see https://github.com/tschaub/gh-pages/issues/345
+        run: |
+          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          ./script/cd

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "parcel src/index.html -p 8082",
     "clean": "rm -rf dist",
     "build": "NODE_ENV=production && parcel build src/index.html && copyfiles CNAME dist",
-    "deploy": "gh-pages -d dist",
+    "deploy": "gh-pages -d dist -u \"github-actions-bot <support+actions@github.com>\"",
     "format": "prettier --write \"src/**/*.js\""
   },
   "repository": {


### PR DESCRIPTION
## What does this change?
The CD actions is currently failing because:

> *** Please tell me who you are.
Run
  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"
to set your account's default identity.
Omit --global to set the identity only in this repository.
fatal: empty ident name (for <runner@fv-az59.etfqdfk4xyru1l5ijc3mck2mlh.cx.internal.cloudapp.net>) not allowed

https://github.com/tschaub/gh-pages/issues/345 suggests we need to do some magic beforehand.

## How can we measure success?
CD works 🙏 

## Images
n/a