### PR TITLE
Allow multiple colours

### DIFF
--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -103,6 +103,8 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
         <label htmlFor="standfirstMedium">Medium</label>
       </fieldset>
 
+      <ColourPicker id="standfirst" colour={props.furniture?.standfirstColour} update={colour => update('standfirstColour', colour)}/>
+
       <fieldset>
         <legend>Position</legend>
         <input

--- a/src/types/furniture.d.ts
+++ b/src/types/furniture.d.ts
@@ -9,6 +9,7 @@ export interface Furniture {
   headlineColour: string
   standfirst: string
   standfirstSize: StandfirstSize
+  standfirstColour: string
   position: number
 }
 

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -252,6 +252,8 @@ class CanvasCard {
           });
         }
 
+        canvasContext.fillStyle = furniture.standfirstColour;
+
         if (splitStandfirst.length > 0) {
           const standfirstOffset = availableHeight * furniture.position / 100 + headlineHeight
           this._drawText({

--- a/src/utils/furniture-helpers.ts
+++ b/src/utils/furniture-helpers.ts
@@ -10,6 +10,7 @@ export default function(): Furniture {
     headlineColour: config.swatches.simple.white,
     standfirst: "",
     standfirstSize: StandfirstSize.Small,
+    standfirstColour: config.swatches.simple.white,
     position: 0,
     device: Device.Mobile,
     imageUrl: "",


### PR DESCRIPTION
## What does this change?
This PR builds on the [convert to react](https://github.com/guardian/editions-card-builder/pull/44) changes and reuses the colour picker component to select a standfirst colour. This colour is then used in the canvas rendering for the standfirst text. 

## How can we measure success?
The user should be able to set the headline text and standfirst text colour separately. See this [trello card](https://trello.com/c/VqsF3OZf/271-headline-and-standfirst-have-different-colours) for more details. 

## Images

![image](https://user-images.githubusercontent.com/4633246/86745959-9fcafe80-c032-11ea-9e74-c38d75a1e8bf.png)
