### PR TITLE
Hide the grid link if the upload button is pressed again

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -13,7 +13,7 @@ interface HeaderProps {
 export default function(props: HeaderProps){
   const {canvasBlob} = props;
 
-  const [gridLink, setGridLink] = useState("");
+  const [gridLink, setGridLink] = useState<string>();
   const [uploading, setUploading] = useState(false);
 
   const uploadImage = () => {
@@ -50,7 +50,7 @@ export default function(props: HeaderProps){
       });
 
       if(canvasBlob){
-        setGridLink("");
+        setGridLink(undefined);
         upload(canvasBlob);
       }
   }

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -50,6 +50,7 @@ export default function(props: HeaderProps){
       });
 
       if(canvasBlob){
+        setGridLink("");
         upload(canvasBlob);
       }
   }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Before the react conversion, the grid link would disappear if the upload button was pressed additional times until it had finished uploading again. This was a useful feature as it would allow a user to see if the upload process had finished at a glance. This PR reintroduces this feature that was lost during the react conversion.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
The grid link is not visible when an item is uploading, and becomes visible once the process has finished. 
