### PR TITLE
Fixes custom colours not working because of duplicate ids

### DIFF
--- a/src/components/colour-picker.tsx
+++ b/src/components/colour-picker.tsx
@@ -13,6 +13,7 @@ export default(props: {id: string, colour?: string, update: (colour: string) => 
     let colour = Object.values(swatch).find(() => true) as string
     props.update(colour);
     setSwatch(event.target.value);
+    setCustom(false);
   }
 
   function findSwatch(name: string){
@@ -63,7 +64,7 @@ export default(props: {id: string, colour?: string, update: (colour: string) => 
           id={`${props.id}_${name}`}
           name={`${props.id}_${name}`}
           onChange={() => updateColour(value)}
-          checked={props.colour == value}/>
+          checked={props.colour == value && !custom}/>
           <label
           htmlFor={`${props.id}_${name}`}
           css={{backgroundColor: value, textTransform: 'capitalize', color: contrastTextColor(value)}}
@@ -74,20 +75,21 @@ export default(props: {id: string, colour?: string, update: (colour: string) => 
       <div>
         <input
           type="radio"
-          id="colourCustom"
-          name="colour"
+          id={`${props.id}_colourCustom`}
+          name={`${props.id}_colour`}
           value="custom"
-          checked={custom == true}
+          checked={custom}
           onChange={() => setCustom(true)}
         />
-        <label htmlFor="colourCustom">Custom</label>
-        <input
-          id="customColour"
-          name="customColour"
+        <label htmlFor={`${props.id}_colourCustom`}>Custom</label>
+        {custom ? <input
+          id={`${props.id}_customColour`}
+          name={`${props.id}_customColour`}
+          css={{width: "150px"}}
           type="text"
           value={props.colour}
           onChange={event => props.update(event.target.value)}
-        />
+        /> : null}
       </div>
     </fieldset>
   </div>);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -267,16 +267,6 @@ input[type="radio"]:checked + label {
   font-weight: 600;
 }
 
-#customColour {
-  display: none;
-  width: 150px;
-}
-
-#colourCustom:checked ~ #customColour {
-  display: inline-block
-}
-
-
 #customPosition {
   display: none;
   width: 150px;


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR fixes an issue with selecting custom colours, due to the options having the same Id. It fixes that issue by prepending the id with the component prop Id. This is the same way the other radio options have unique Ids. 

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Pressing the second custom colour option should work as expected. 
