### PR TITLE
Add byline and kicker

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -32,6 +32,7 @@ class App extends React.Component<any, AppState> {
 
   updateFurniture = (newFurniture: Furniture) => {
     this.setState({
+      canvasBlob: undefined,
       furniture: newFurniture
     })
   }

--- a/src/components/collapsible.tsx
+++ b/src/components/collapsible.tsx
@@ -25,7 +25,7 @@ export default class Modal extends React.Component<collapsibleProps, collapsible
   render(){
     return(
     <div>
-      <button type="button" className="collapsible" onClick={() => this.setState({show: !this.state.show})}>{this.props.name}</button>
+      <button type="button" className={`collapsible ${this.state.show? "active" : ""}`} onClick={() => this.setState({show: !this.state.show})}>{this.props.name}</button>
       <div css={{display: this.state.show ? "inherit" : "none"}}>
         {this.props.children}
       </div>

--- a/src/components/collapsible.tsx
+++ b/src/components/collapsible.tsx
@@ -1,0 +1,35 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/core'
+import * as React from 'react';
+
+
+interface collapsibleProps{
+  name: string
+}
+
+interface collapsibleState{
+  show: boolean
+}
+
+
+export default class Modal extends React.Component<collapsibleProps, collapsibleState> {
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      show: false
+    }
+  }
+
+
+
+  render(){
+    return(
+    <div>
+      <button type="button" className="collapsible" onClick={() => this.setState({show: !this.state.show})}>{this.props.name}</button>
+      <div css={{display: this.state.show ? "inherit" : "none"}}>
+        {this.props.children}
+      </div>
+    </div>
+    );
+  }
+}

--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -36,7 +36,7 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
             placeholder="headline..."
             value={props.furniture?.headline}
             onChange={event => update('headline', event.target.value)}
-          ></textarea>
+          />
 
           <fieldset>
             <legend>Size</legend>
@@ -81,9 +81,9 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
             id="kicker"
             name="kicker"
             placeholder="kicker..."
-            value={props.furniture?.kicker}
+            value={props.furniture?.kicker || ""}
             onChange={event => update('kicker', event.target.value)}
-          ></input>
+          />
 
           <ColourPicker id="kicker" colour={props.furniture?.kickerColour} update={colour => update('kickerColour', colour)}/>
         </Collapsible>
@@ -96,7 +96,7 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
             placeholder="standfirst..."
             value={props.furniture?.standfirst}
             onChange={event => update('standfirst', event.target.value)}
-          ></textarea>
+          />
 
           <fieldset>
             <legend>Size</legend>
@@ -130,9 +130,9 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
             id="byline"
             name="byline"
             placeholder="byline..."
-            value={props.furniture?.kicker}
+            value={props.furniture?.byline || ""}
             onChange={event => update('byline', event.target.value)}
-          ></input>
+          />
 
           <ColourPicker id="byline" colour={props.furniture?.bylineColour} update={colour => update('bylineColour', colour)}/>
         </Collapsible>

--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -134,7 +134,7 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
             onChange={event => update('byline', event.target.value)}
           ></input>
 
-          <ColourPicker id="byline" colour={props.furniture?.bylineColour} update={colour => update('byline', colour)}/>
+          <ColourPicker id="byline" colour={props.furniture?.bylineColour} update={colour => update('bylineColour', colour)}/>
         </Collapsible>
 
         <Collapsible name="Position">

--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -3,6 +3,7 @@ import { jsx } from '@emotion/core'
 import Config from "../utils/config";
 import ColourPicker from "./colour-picker"
 import ImageSelect from "./image-select"
+import Collapsible from "./collapsible"
 import { useState } from 'react'
 import { Furniture } from '../types/furniture';
 import { HeadlineSize, StandfirstSize } from '../enums/size';
@@ -27,160 +28,195 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
       <form className="card-builder-form">
         <ImageSelect updateImageUrl={imageUrl => update('imageUrl', imageUrl)} updateOriginalImageData={props.updateOriginalImageData} />
 
-        <label htmlFor="headline">Headline</label>
-        <textarea
-          id="headline"
-          name="headline"
-          placeholder="headline..."
-          value={props.furniture?.headline}
-          onChange={event => update('headline', event.target.value)}
-        ></textarea>
+        <Collapsible name="Headline">
+          <label htmlFor="headline">Text</label>
+          <textarea
+            id="headline"
+            name="headline"
+            placeholder="headline..."
+            value={props.furniture?.headline}
+            onChange={event => update('headline', event.target.value)}
+          ></textarea>
 
-      <fieldset>
-        <legend>Headline Size</legend>
-        <input
-          type="radio"
-          id="headlineSmall"
-          name="headlineSize"
-          value={HeadlineSize.Small}
-          checked={props.furniture?.headlineSize === HeadlineSize.Small}
-          onChange={event => update('headlineSize', event.target.value)}
-        />
-        <label htmlFor="headlineSmall">Small</label>
+          <fieldset>
+            <legend>Size</legend>
+            <input
+              type="radio"
+              id="headlineSmall"
+              name="headlineSize"
+              value={HeadlineSize.Small}
+              checked={props.furniture?.headlineSize === HeadlineSize.Small}
+              onChange={event => update('headlineSize', event.target.value)}
+            />
+            <label htmlFor="headlineSmall">Small</label>
 
-        <input
-          type="radio"
-          id="headlineMedium"
-          name="headlineSize"
-          value={HeadlineSize.Medium}
-          checked={props.furniture?.headlineSize === HeadlineSize.Medium}
-          onChange={event => update('headlineSize', event.target.value)}
-        />
-        <label htmlFor="headlineMedium">Medium</label>
+            <input
+              type="radio"
+              id="headlineMedium"
+              name="headlineSize"
+              value={HeadlineSize.Medium}
+              checked={props.furniture?.headlineSize === HeadlineSize.Medium}
+              onChange={event => update('headlineSize', event.target.value)}
+            />
+            <label htmlFor="headlineMedium">Medium</label>
 
-        <input
-          type="radio"
-          id="headlineLarge"
-          name="headlineSize"
-          value={HeadlineSize.Large}
-          checked={props.furniture?.headlineSize === HeadlineSize.Large}
-          onChange={event => update('headlineSize', event.target.value)}
-        />
-        <label htmlFor="headlineLarge">Large</label>
-      </fieldset>
+            <input
+              type="radio"
+              id="headlineLarge"
+              name="headlineSize"
+              value={HeadlineSize.Large}
+              checked={props.furniture?.headlineSize === HeadlineSize.Large}
+              onChange={event => update('headlineSize', event.target.value)}
+            />
+            <label htmlFor="headlineLarge">Large</label>
+          </fieldset>
 
-      <ColourPicker id="headline" colour={props.furniture?.headlineColour} update={colour => update('headlineColour', colour)}/>
+          <ColourPicker id="headline" colour={props.furniture?.headlineColour} update={colour => update('headlineColour', colour)}/>
+        </Collapsible>
 
-      <label htmlFor="standfirst">Standfirst</label>
-      <textarea
-        id="standfirst"
-        name="standfirst"
-        placeholder="standfirst..."
-        value={props.furniture?.standfirst}
-        onChange={event => update('standfirst', event.target.value)}
-      ></textarea>
-
-      <fieldset>
-        <legend>Standfirst Size</legend>
-        <input
-          type="radio"
-          id="standfirstSmall"
-          name="standfirstSize"
-          value={StandfirstSize.Small}
-          checked={props.furniture?.standfirstSize === StandfirstSize.Small}
-          onChange={event => update('standfirstSize', event.target.value)}
-        />
-        <label htmlFor="standfirstSmall">Small</label>
-
-        <input
-          type="radio"
-          id="standfirstMedium"
-          name="standfirstSize"
-          value={StandfirstSize.Medium}
-          checked={props.furniture?.standfirstSize === StandfirstSize.Medium}
-          onChange={event => update('standfirstSize', event.target.value)}
-        />
-        <label htmlFor="standfirstMedium">Medium</label>
-      </fieldset>
-
-      <ColourPicker id="standfirst" colour={props.furniture?.standfirstColour} update={colour => update('standfirstColour', colour)}/>
-
-      <fieldset>
-        <legend>Position</legend>
-        <input
-          type="radio"
-          id="positionTop"
-          name="positionValue"
-          value="top"
-          checked={position == "top"}
-          onChange={event => updatePostion("top", 0)}
-        />
-        <label htmlFor="positionTop">Top</label>
-
-        <input
-          type="radio"
-          id="positionMiddle"
-          name="positionValue"
-          value="middle"
-          checked={position == "middle"}
-          onChange={event => updatePostion("middle", 40)}
-        />
-        <label htmlFor="positionMiddle">Middle</label>
-        <input
-          type="radio"
-          id="positionBottom"
-          name="positionValue"
-          value="bottom"
-          checked={position == "bottom"}
-          onChange={event => updatePostion("bottom", 100)}
-        />
-        <label htmlFor="positionBottom">Bottom</label>
-        <br/>
-        <div>
+        <Collapsible name="Kicker">
+          <label htmlFor="kicker">Text</label>
           <input
-            type="radio"
-            id="positionCustom"
-            name="positionValue"
-            checked={position == "custom"}
-            onChange={() => updatePostion("custom", 50)}
-            value="custom"
-          />
-          <label htmlFor="positionCustom">Custom</label>
+            type="text"
+            id="kicker"
+            name="kicker"
+            placeholder="kicker..."
+            value={props.furniture?.kicker}
+            onChange={event => update('kicker', event.target.value)}
+          ></input>
+
+          <ColourPicker id="kicker" colour={props.furniture?.kickerColour} update={colour => update('kickerColour', colour)}/>
+        </Collapsible>
+
+        <Collapsible name="Standfirst">
+          <label htmlFor="standfirst">Text</label>
+          <textarea
+            id="standfirst"
+            name="standfirst"
+            placeholder="standfirst..."
+            value={props.furniture?.standfirst}
+            onChange={event => update('standfirst', event.target.value)}
+          ></textarea>
+
+          <fieldset>
+            <legend>Size</legend>
+            <input
+              type="radio"
+              id="standfirstSmall"
+              name="standfirstSize"
+              value={StandfirstSize.Small}
+              checked={props.furniture?.standfirstSize === StandfirstSize.Small}
+              onChange={event => update('standfirstSize', event.target.value)}
+            />
+            <label htmlFor="standfirstSmall">Small</label>
+
+            <input
+              type="radio"
+              id="standfirstMedium"
+              name="standfirstSize"
+              value={StandfirstSize.Medium}
+              checked={props.furniture?.standfirstSize === StandfirstSize.Medium}
+              onChange={event => update('standfirstSize', event.target.value)}
+            />
+            <label htmlFor="standfirstMedium">Medium</label>
+          </fieldset>
+          <ColourPicker id="standfirst" colour={props.furniture?.standfirstColour} update={colour => update('standfirstColour', colour)}/>
+        </Collapsible>
+
+        <Collapsible name="Byline">
+          <label htmlFor="byline">Text</label>
           <input
-            id="customPosition"
-            name="customPosition"
-            type="range"
-            value={props.furniture?.position}
-            min="1"
-            max="99"
-            onChange={event => updatePostion("custom", event.target.value)}
-          />
-        </div>
+            type="text"
+            id="byline"
+            name="byline"
+            placeholder="byline..."
+            value={props.furniture?.kicker}
+            onChange={event => update('byline', event.target.value)}
+          ></input>
 
-      </fieldset>
+          <ColourPicker id="byline" colour={props.furniture?.bylineColour} update={colour => update('byline', colour)}/>
+        </Collapsible>
 
-      <fieldset>
-        <legend>Device</legend>
-        <input
-          type="radio"
-          id="deviceMobile"
-          name="device"
-          value={Device.Mobile}
-          checked={props.furniture?.device === Device.Mobile}
-          onChange={event => update('device', event.target.value)}
-        />
-        <label htmlFor="deviceMobile">Mobile</label>
+        <Collapsible name="Position">
+          <fieldset>
+            <legend>Position</legend>
+            <input
+              type="radio"
+              id="positionTop"
+              name="positionValue"
+              value="top"
+              checked={position == "top"}
+              onChange={event => updatePostion("top", 0)}
+            />
+            <label htmlFor="positionTop">Top</label>
 
-        <input
-          type="radio"
-          id="deviceTablet"
-          name="device"
-          value={Device.Tablet}
-          checked={props.furniture?.device === Device.Tablet}
-          onChange={event => update('device', event.target.value)}
-        />
-        <label htmlFor="deviceTablet">Tablet</label>
-      </fieldset>
+            <input
+              type="radio"
+              id="positionMiddle"
+              name="positionValue"
+              value="middle"
+              checked={position == "middle"}
+              onChange={event => updatePostion("middle", 40)}
+            />
+            <label htmlFor="positionMiddle">Middle</label>
+            <input
+              type="radio"
+              id="positionBottom"
+              name="positionValue"
+              value="bottom"
+              checked={position == "bottom"}
+              onChange={event => updatePostion("bottom", 100)}
+            />
+            <label htmlFor="positionBottom">Bottom</label>
+            <br/>
+            <div>
+              <input
+                type="radio"
+                id="positionCustom"
+                name="positionValue"
+                checked={position == "custom"}
+                onChange={() => updatePostion("custom", 50)}
+                value="custom"
+              />
+              <label htmlFor="positionCustom">Custom</label>
+              <input
+                id="customPosition"
+                name="customPosition"
+                type="range"
+                value={props.furniture?.position}
+                min="1"
+                max="99"
+                onChange={event => updatePostion("custom", event.target.value)}
+              />
+            </div>
+
+          </fieldset>
+        </Collapsible>
+
+        <Collapsible name="Device">
+          <fieldset>
+            <legend>Device</legend>
+            <input
+              type="radio"
+              id="deviceMobile"
+              name="device"
+              value={Device.Mobile}
+              checked={props.furniture?.device === Device.Mobile}
+              onChange={event => update('device', event.target.value)}
+            />
+            <label htmlFor="deviceMobile">Mobile</label>
+
+            <input
+              type="radio"
+              id="deviceTablet"
+              name="device"
+              value={Device.Tablet}
+              checked={props.furniture?.device === Device.Tablet}
+              onChange={event => update('device', event.target.value)}
+            />
+            <label htmlFor="deviceTablet">Tablet</label>
+          </fieldset>
+        </Collapsible>
     </form>
     </div>
   )

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -70,8 +70,8 @@ export default function(props: HeaderProps){
       </div>
       <div>
         {!!gridLink ? <a href={gridLink} id="gridLink" target="_blank" rel="noopener noreferrer">🖼 Grid</a> : null}
-        {!!canvasBlob ? <button id="upload" onClick={uploadImage}>{uploading ? "Uploading" : "Upload"}</button>: null}
-        {!!canvasBlob ? <button id="download" onClick={downloadImage}>Download</button> : null}
+        <button id="upload" onClick={uploadImage} disabled={!canvasBlob}>{uploading ? "Uploading" : "Upload"}</button>
+        <button id="download" onClick={downloadImage} disabled={!canvasBlob}>Download</button>
       </div>
     </header>
   )

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -321,6 +321,18 @@ button.collapsible {
   background-color: #424242
 }
 
+button.collapsible:after {
+  content: '\002B';
+  color: white;
+  font-weight: bold;
+  float: right;
+  margin-left: 5px;
+}
+
+button.collapsible.active:after {
+  content: "\2212";
+}
+
 canvas {
   height: 80%;
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -312,6 +312,15 @@ button:not([disabled]):hover {
   cursor: pointer;
 }
 
+button.collapsible {
+  cursor: pointer;
+  width: 100%;
+  border: none;
+  text-align: left;
+  outline: none;
+  background-color: #424242
+}
+
 canvas {
   height: 80%;
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -224,7 +224,7 @@ header h1 {
 .card-builder-form legend {
   display: block;
   font-family: "Guardian Titlepiece";
-  font-size: 18px;
+  font-size: 15px;
   padding-top: var(--spacing);
 }
 
@@ -318,7 +318,9 @@ button.collapsible {
   border: none;
   text-align: left;
   outline: none;
-  background-color: #424242
+  background-color: #424242;
+  font-size: 16px;
+  padding-left: 8px;
 }
 
 button.collapsible:after {

--- a/src/types/furniture.d.ts
+++ b/src/types/furniture.d.ts
@@ -3,13 +3,17 @@ import { HeadlineSize, StandfirstSize } from "../enums/size";
 
 export interface Furniture {
   device: Device
-  imageUrl: string
-  headline: string
+  imageUrl: string | undefined
+  headline: string | undefined
   headlineSize: HeadlineSize
   headlineColour: string
-  standfirst: string
+  kicker: string | undefined
+  kickerColour: string
+  standfirst: string | undefined
   standfirstSize: StandfirstSize
   standfirstColour: string
+  byline: string | undefined
+  bylineColour: string
   position: number
 }
 

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -97,8 +97,8 @@ class CanvasCard {
 
     //Do last split kick and first headline fit together on a line?
     const fristHeadline = splitHeadlineAndKicker[0]
-    const firstHeadlineMinusKicker = splitHeadlineAndKicker[0].substr(lastKickerLine.length, fristHeadline.length).trim();
-    const kickerAndHeadlineisMixed = headlineRenderer.doesTextFit(`${lastKickerLine} ${firstHeadlineMinusKicker}`) && fristHeadline.length != lastKickerLine.length;
+    const firstHeadlineMinusKicker = splitHeadlineAndKicker[0].substr(lastKickerLine.length, fristHeadline.length);
+    const kickerAndHeadlineisMixed = headlineRenderer.doesTextFit(`${lastKickerLine.trim()} ${firstHeadlineMinusKicker.trim()}`) && fristHeadline.length != lastKickerLine.length;
 
     //If yes
     if(kickerAndHeadlineisMixed){
@@ -158,8 +158,9 @@ class CanvasCard {
       padding: Config.padding
     });
 
+    const kickerAndHeadlineText = `${furniture.kicker ? furniture.kicker + " " : ""}${furniture.headline || ""}`
 
-    const splitHeadlineAndKicker = !furniture.headline && !furniture.kicker ? [] : headlineAndKickerRenderer.splitTextIntoLines(`${furniture.kicker} ${furniture.headline}`);
+    const splitHeadlineAndKicker = !furniture.headline && !furniture.kicker ? [] : headlineAndKickerRenderer.splitTextIntoLines(kickerAndHeadlineText);
     const splitStandfirst = !furniture.standfirst ? [] : standfirstAndBylineRenderer.splitTextIntoLines(furniture.standfirst);
     const splitByline = !furniture.byline ? [] : standfirstAndBylineRenderer.splitTextIntoLines(furniture.byline);
 

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -174,23 +174,23 @@ class CanvasCard {
       this._drawKickerAndHeadline(headlineAndKickerRenderer, canvas, furniture, scale, availableHeight);
     }
     else if (!!furniture.headline) {
-      const splitHeadline = !furniture.headline ? [] : headlineAndKickerRenderer.splitTextIntoLines(`${furniture.headline}`);
-      const headlineOffset = availableHeight * furniture.position / 100
+      const splitHeadline = headlineAndKickerRenderer.splitTextIntoLines(furniture.headline);
+      const headlineOffset = availableHeight * furniture.position / 100;
       headlineAndKickerRenderer.drawText(splitHeadline, 0, headlineOffset, furniture.headlineColour);
     }
     else if(!!furniture.kicker) {
-      const splitKicker = !furniture.headline ? [] : headlineAndKickerRenderer.splitTextIntoLines(`${furniture.kicker}`);
-      const kickerOffset = availableHeight * furniture.position / 100
+      const splitKicker = headlineAndKickerRenderer.splitTextIntoLines(furniture.kicker);
+      const kickerOffset = availableHeight * furniture.position / 100;
       headlineAndKickerRenderer.drawText(splitKicker, 0, kickerOffset, furniture.kickerColour);
     }
 
     if (splitStandfirst.length > 0) {
-      const standfirstOffset = availableHeight * furniture.position / 100 + headlineHeight
+      const standfirstOffset = availableHeight * furniture.position / 100 + headlineHeight;
       standfirstAndBylineRenderer.drawText(splitStandfirst, 0, standfirstOffset, furniture.standfirstColour);
     }
 
     if (splitByline.length > 0) {
-      const bylineOffset = availableHeight * furniture.position / 100 + headlineHeight + standfirstHeight
+      const bylineOffset = availableHeight * furniture.position / 100 + headlineHeight + standfirstHeight;
       standfirstAndBylineRenderer.drawText(splitByline, 0, bylineOffset, furniture.bylineColour);
     }
   }

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -144,7 +144,7 @@ class CanvasCard {
     });
   }
 
-  _getImageDataUrl({ imageUrl }: {imageUrl: string}) {
+  _getImageDataUrl(imageUrl: string) {
     const key = encodeURIComponent(imageUrl);
     const maybeItem = this.imageCache.get(key);
 
@@ -169,8 +169,8 @@ class CanvasCard {
       });
   }
 
-  _getImage({ imageUrl }: {imageUrl: string}) {
-    return this._getImageDataUrl({ imageUrl }).then(
+  _getImage(imageUrl: string) {
+    return this._getImageDataUrl(imageUrl).then(
       dataUrl =>
         new Promise<HTMLImageElement>(resolve => {
           const image = new Image();
@@ -188,7 +188,7 @@ class CanvasCard {
       return Promise.reject("no-image");
     }
 
-    return this._getImage(furniture).then(image => {
+    return this._getImage(furniture.imageUrl).then(image => {
       const [deviceWidth, deviceHeight] = Config.dimensions[furniture.device];
 
       const { width, height, scale } = this._getCanvasDimensions({

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -1,6 +1,8 @@
 import Config from "./config";
 import { Furniture } from "../types/furniture";
 import { promises } from "fs";
+import { line } from "@guardian/src-foundations/palette";
+import { TextRenderer } from "./text-renderer"
 
 class CanvasCard {
 
@@ -10,7 +12,7 @@ class CanvasCard {
     this.imageCache = new Map();
   }
 
-  _getCanvasDimensions({ deviceWidth, deviceHeight, imageWidth, imageHeight }:
+  private _getCanvasDimensions({ deviceWidth, deviceHeight, imageWidth, imageHeight }:
      { deviceWidth: number, deviceHeight: number, imageWidth: number, imageHeight: number }) {
     //For each unit of width, the image has this height
     const deviceRatio = deviceWidth / deviceHeight;
@@ -28,7 +30,8 @@ class CanvasCard {
       scale: imageWidth / deviceWidth
     };
   }
-  _drawImage({ canvasContext, image }: { canvasContext: CanvasRenderingContext2D, image: HTMLImageElement }) {
+
+  private _drawImage({ canvasContext, image }: { canvasContext: CanvasRenderingContext2D, image: HTMLImageElement }) {
     const x = 0;
     const y = 0;
     const xOffset = 0.5;
@@ -80,164 +83,119 @@ class CanvasCard {
     );
   }
 
-  _doesTextFit({ canvasContext, maxWidth, text }: { canvasContext: CanvasRenderingContext2D, maxWidth: number, text: string }) {
-    const measure = canvasContext.measureText(text);
-    return measure.width < maxWidth;
-  }
+  private _drawKickerAndHeadline(headlineRenderer: TextRenderer, canvas: HTMLCanvasElement, furniture: Furniture, scale: number, availableHeight: number){
+    //Split kicker into multiple lines
+    const splitKicker = headlineRenderer.splitTextIntoLines(furniture.kicker as string);
+    const lastKickerLine = splitKicker[splitKicker.length - 1];
 
-  _splitTextIntoLines({ canvasContext, maxWidth, text, font, fontSize }:
-  { canvasContext: CanvasRenderingContext2D, maxWidth: number, text: string, font: string, fontSize: number }) {
-    canvasContext.font = `${fontSize}px ${font}`;
+    //split split kicker last line and rest of headline
+    const splitHeadlineAndKicker = headlineRenderer.splitTextIntoLines(`${lastKickerLine} ${furniture.headline}`);
 
-    const measured = text.split("").reduce(
-      ({ buffer, lines }: {buffer: string, lines: any}, char: string) => {
-        const newBuffer = buffer + char;
-        //Are we on a newline?
-        if (char === "\n") {
-          return { lines: [...lines, buffer], buffer: "" };
-        }
-        //Does the text fit ok?
-        if (this._doesTextFit({ canvasContext, maxWidth, text: newBuffer })) {
-          return { lines: lines, buffer: newBuffer };
-        }
-
-        //Can we split at a space?
-        const lastSpace = newBuffer.lastIndexOf(" ");
-        if (lastSpace !== -1) {
-          const left = newBuffer.substring(0, lastSpace);
-          const right = newBuffer.substring(lastSpace + 1);
-          return {
-            lines: [...lines, left],
-            buffer: right
-          };
-        }
-        return { lines: [...lines, buffer], buffer: char };
-      },
-      { buffer: "", lines: [] }
-    );
-
-    return [...measured.lines, measured.buffer];
-  }
-
-  _drawText({
-    canvasContext,
-    lines,
-    fontSize,
-    font,
-    initialOffset,
-    lineHeight,
-    scale,
-    colour
-  }:
-  {
-    canvasContext: CanvasRenderingContext2D,
-    lines: string[],
-    fontSize: number,
-    font: string,
-    initialOffset: number,
-    lineHeight: number,
-    scale: number,
-    colour: string
-  }) {
-    canvasContext.font = `${fontSize}px ${font}`;
-    canvasContext.fillStyle = colour;
-    lines.forEach((line, i) => {
-      const yOffset = initialOffset + lineHeight * (i + 1);
-      canvasContext.fillText(line, Config.padding * scale, yOffset);
-    });
-  }
-
-  _drawFurniture(canvas: HTMLCanvasElement ,canvasContext: CanvasRenderingContext2D, furniture: Furniture, scale: number){
-    const splitHeadline = !furniture.headline && !furniture.kicker
-      ? []
-      : this._splitTextIntoLines({
-          canvasContext,
-          maxWidth: Config.headline[furniture.device].maxWidth * scale,
-          text: `${furniture.kicker || ""}${furniture.headline || ""}`,
-          font: Config.headline.font,
-          fontSize: Config.headline[furniture.device].fontSize[furniture.headlineSize] * scale
-        });
-
-    const splitStandfirst = !furniture.standfirst
-      ? []
-      : this._splitTextIntoLines({
-          canvasContext,
-          maxWidth: Config.standfirst[furniture.device].maxWidth * scale,
-          text: furniture.standfirst,
-          font: Config.standfirst.font,
-          fontSize: Config.standfirst[furniture.device].fontSize[furniture.standfirstSize] * scale
-        });
-
-    const splitByline = !furniture.byline
-      ? []
-      : this._splitTextIntoLines({
-          canvasContext,
-          maxWidth: Config.standfirst[furniture.device].maxWidth * scale,
-          text: furniture.byline,
-          font: Config.standfirst.font,
-          fontSize: Config.standfirst[furniture.device].fontSize[furniture.standfirstSize] * scale
-        });
-
-    const headlineHeight =
-      (splitHeadline.length * Config.headline[furniture.device].lineHeight[furniture.headlineSize] +
-        Config.padding) *
+    const lineHeight =
+      (Config.headline[furniture.device].lineHeight[furniture.headlineSize]) *
       scale;
-    const standfirstHeight =
-      splitStandfirst.length *
-      Config.standfirst[furniture.device].lineHeight[furniture.standfirstSize] * scale;
-    const bylineHeight =
-      splitByline.length *
-      Config.standfirst[furniture.device].lineHeight[furniture.standfirstSize] * scale;
 
+    //Do last split kick and first headline fit together on a line?
+    const fristHeadline = splitHeadlineAndKicker[0]
+    const firstHeadlineMinusKicker = splitHeadlineAndKicker[0].substr(lastKickerLine.length, fristHeadline.length).trim();
+    const kickerAndHeadlineisMixed = headlineRenderer.doesTextFit(`${lastKickerLine} ${firstHeadlineMinusKicker}`) && fristHeadline.length != lastKickerLine.length;
+
+    //If yes
+    if(kickerAndHeadlineisMixed){
+      const lineCount = splitKicker.length + splitHeadlineAndKicker.length - 1;
+      //render all lines but last
+      if(splitKicker.length > 1){
+        const kickerOffset = availableHeight * furniture.position / 100;
+        headlineRenderer.drawText(splitKicker.slice(0, splitKicker.length - 1), 0, kickerOffset, furniture.kickerColour);
+      }
+
+      //Render last kicker line
+      const lastKickerOfest = availableHeight * furniture.position / 100 + (lineHeight * (splitKicker.length - 1));
+      headlineRenderer.drawText([lastKickerLine], 0, lastKickerOfest, furniture.kickerColour);
+
+      //Render rest of rest of first headline
+      const xOffset = headlineRenderer.measureTextWidth(lastKickerLine);
+      headlineRenderer.drawText([firstHeadlineMinusKicker],xOffset, lastKickerOfest,furniture.headlineColour);
+
+      //Render rest of headline lines
+      if(splitHeadlineAndKicker.length > 1) {
+        const headlineOffset = availableHeight * furniture.position / 100 + (lineHeight * splitKicker.length);
+        headlineRenderer.drawText(splitHeadlineAndKicker.slice(1, splitHeadlineAndKicker.length), 0, headlineOffset, furniture.headlineColour);
+      }
+    }
+    //If No
+    else {
+      const lineCount = splitKicker.length + splitHeadlineAndKicker.length - 1;
+      //Render kicker lines
+      const kickerOffset = availableHeight * furniture.position / 100;
+      headlineRenderer.drawText(splitKicker, 0, kickerOffset, furniture.kickerColour);
+
+      //Render headline lines
+      const headlineOffset = availableHeight * furniture.position / 100 + (lineHeight * splitKicker.length);
+      headlineRenderer.drawText(splitHeadlineAndKicker.slice(1, splitHeadlineAndKicker.length), 0, headlineOffset, furniture.headlineColour);
+    }
+  }
+
+  private _drawFurniture(canvas: HTMLCanvasElement ,canvasContext: CanvasRenderingContext2D, furniture: Furniture, scale: number){
+
+    const headlineAndKickerRenderer = new TextRenderer({
+      canvasContext,
+      maxWidth: Config.headline[furniture.device].maxWidth * scale,
+      font: Config.headline.font,
+      fontSize: Config.headline[furniture.device].fontSize[furniture.headlineSize] * scale,
+      lineHeight: Config.headline[furniture.device].lineHeight[furniture.headlineSize] * scale,
+      scale: scale,
+      padding: Config.padding
+    });
+
+    const standfirstAndBylineRenderer = new TextRenderer({
+      canvasContext,
+      maxWidth: Config.standfirst[furniture.device].maxWidth * scale,
+      font: Config.standfirst.font,
+      fontSize: Config.standfirst[furniture.device].fontSize[furniture.standfirstSize] * scale,
+      lineHeight: Config.standfirst[furniture.device].lineHeight[furniture.standfirstSize] * scale,
+      scale: scale,
+      padding: Config.padding
+    });
+
+
+    const splitHeadlineAndKicker = !furniture.headline && !furniture.kicker ? [] : headlineAndKickerRenderer.splitTextIntoLines(`${furniture.kicker} ${furniture.headline}`);
+    const splitStandfirst = !furniture.standfirst ? [] : standfirstAndBylineRenderer.splitTextIntoLines(furniture.standfirst);
+    const splitByline = !furniture.byline ? [] : standfirstAndBylineRenderer.splitTextIntoLines(furniture.byline);
+
+    const headlineHeight = (splitHeadlineAndKicker.length * Config.headline[furniture.device].lineHeight[furniture.headlineSize] + Config.padding) * scale;
+    const standfirstHeight = splitStandfirst.length * Config.standfirst[furniture.device].lineHeight[furniture.standfirstSize] * scale;
+    const bylineHeight = splitByline.length * Config.standfirst[furniture.device].lineHeight[furniture.standfirstSize] * scale;
 
     const availableHeight = canvas.height - bylineHeight - standfirstHeight - headlineHeight - Config.padding * scale
 
 
-    if (splitHeadline.length > 0) {
-
+    if(!!furniture.headline && !!furniture.kicker){
+      this._drawKickerAndHeadline(headlineAndKickerRenderer, canvas, furniture, scale, availableHeight);
+    }
+    else if (!!furniture.headline) {
+      const splitHeadline = !furniture.headline ? [] : headlineAndKickerRenderer.splitTextIntoLines(`${furniture.headline}`);
       const headlineOffset = availableHeight * furniture.position / 100
-      this._drawText({
-        canvasContext,
-        lines: splitHeadline,
-        font: Config.headline.font,
-        fontSize: Config.headline[furniture.device].fontSize[furniture.headlineSize] * scale,
-        lineHeight: Config.headline[furniture.device].lineHeight[furniture.headlineSize] * scale,
-        initialOffset: headlineOffset,
-        scale,
-        colour: furniture.headlineColour
-      });
+      headlineAndKickerRenderer.drawText(splitHeadline, 0, headlineOffset, furniture.headlineColour);
+    }
+    else if(!!furniture.kicker) {
+      const splitKicker = !furniture.headline ? [] : headlineAndKickerRenderer.splitTextIntoLines(`${furniture.kicker}`);
+      const kickerOffset = availableHeight * furniture.position / 100
+      headlineAndKickerRenderer.drawText(splitKicker, 0, kickerOffset, furniture.kickerColour);
     }
 
     if (splitStandfirst.length > 0) {
       const standfirstOffset = availableHeight * furniture.position / 100 + headlineHeight
-      this._drawText({
-        canvasContext,
-        lines: splitStandfirst,
-        font: Config.standfirst.font,
-        fontSize: Config.standfirst[furniture.device].fontSize[furniture.standfirstSize] * scale,
-        lineHeight: Config.standfirst[furniture.device].lineHeight[furniture.standfirstSize] * scale,
-        initialOffset: standfirstOffset,
-        scale,
-        colour: furniture.standfirstColour
-      });
+      standfirstAndBylineRenderer.drawText(splitStandfirst, 0, standfirstOffset, furniture.standfirstColour);
     }
 
     if (splitByline.length > 0) {
-      const standfirstOffset = availableHeight * furniture.position / 100 + headlineHeight + standfirstHeight
-      this._drawText({
-        canvasContext,
-        lines: splitByline,
-        font: Config.standfirst.font,
-        fontSize: Config.standfirst[furniture.device].fontSize[furniture.standfirstSize] * scale,
-        lineHeight: Config.standfirst[furniture.device].lineHeight[furniture.standfirstSize] * scale,
-        initialOffset: standfirstOffset,
-        scale,
-        colour: furniture.bylineColour
-      });
+      const bylineOffset = availableHeight * furniture.position / 100 + headlineHeight + standfirstHeight
+      standfirstAndBylineRenderer.drawText(splitByline, 0, bylineOffset, furniture.bylineColour);
     }
   }
 
-  _getImageDataUrl(imageUrl: string) : Promise<string> {
+  private _getImageDataUrl(imageUrl: string) : Promise<string> {
     const key = encodeURIComponent(imageUrl);
     const maybeItem = this.imageCache.get(key);
 
@@ -262,7 +220,7 @@ class CanvasCard {
       });
   }
 
-  _getImage(imageUrl: string) {
+  private _getImage(imageUrl: string) {
     return this._getImageDataUrl(imageUrl).then(
       (dataUrl: string) =>
         new Promise<HTMLImageElement>(resolve => {

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -144,6 +144,95 @@ class CanvasCard {
     });
   }
 
+  _drawFurniture(canvas: HTMLCanvasElement ,canvasContext: CanvasRenderingContext2D, furniture: Furniture, scale: number){
+    const splitHeadline = !furniture.headline
+      ? []
+      : this._splitTextIntoLines({
+          canvasContext,
+          maxWidth: Config.headline[furniture.device].maxWidth * scale,
+          text: furniture.headline,
+          font: Config.headline.font,
+          fontSize: Config.headline[furniture.device].fontSize[furniture.headlineSize] * scale
+        });
+
+    const splitStandfirst = !furniture.standfirst
+      ? []
+      : this._splitTextIntoLines({
+          canvasContext,
+          maxWidth: Config.standfirst[furniture.device].maxWidth * scale,
+          text: furniture.standfirst,
+          font: Config.standfirst.font,
+          fontSize: Config.standfirst[furniture.device].fontSize[furniture.standfirstSize] * scale
+        });
+
+    const splitByline = !furniture.byline
+      ? []
+      : this._splitTextIntoLines({
+          canvasContext,
+          maxWidth: Config.standfirst[furniture.device].maxWidth * scale,
+          text: furniture.byline,
+          font: Config.standfirst.font,
+          fontSize: Config.standfirst[furniture.device].fontSize[furniture.standfirstSize] * scale
+        });
+
+    const headlineHeight =
+      (splitHeadline.length * Config.headline[furniture.device].lineHeight[furniture.headlineSize] +
+        Config.padding) *
+      scale;
+    const standfirstHeight =
+      splitStandfirst.length *
+      Config.standfirst[furniture.device].lineHeight[furniture.standfirstSize] * scale;
+    const bylineHeight =
+      splitByline.length *
+      Config.standfirst[furniture.device].lineHeight[furniture.standfirstSize] * scale;
+
+
+    const availableHeight = canvas.height - standfirstHeight - headlineHeight - Config.padding * scale
+
+
+    if (splitHeadline.length > 0) {
+      canvasContext.fillStyle = furniture.headlineColour;
+      const headlineOffset = availableHeight * furniture.position / 100
+      this._drawText({
+        canvasContext,
+        lines: splitHeadline,
+        font: Config.headline.font,
+        fontSize: Config.headline[furniture.device].fontSize[furniture.headlineSize] * scale,
+        lineHeight: Config.headline[furniture.device].lineHeight[furniture.headlineSize] * scale,
+        initialOffset: headlineOffset,
+        scale
+      });
+    }
+
+    if (splitStandfirst.length > 0) {
+      canvasContext.fillStyle = furniture.standfirstColour;
+      const standfirstOffset = availableHeight * furniture.position / 100 + headlineHeight
+      this._drawText({
+        canvasContext,
+        lines: splitStandfirst,
+        font: Config.standfirst.font,
+        fontSize: Config.standfirst[furniture.device].fontSize[furniture.standfirstSize] * scale,
+        lineHeight: Config.standfirst[furniture.device].lineHeight[furniture.standfirstSize] * scale,
+        initialOffset: standfirstOffset,
+        scale
+      });
+    }
+
+    if (splitByline.length > 0) {
+      canvasContext.fillStyle = furniture.bylineColour;
+      const standfirstOffset = availableHeight * furniture.position / 100 + headlineHeight + standfirstHeight
+      this._drawText({
+        canvasContext,
+        lines: splitByline,
+        font: Config.standfirst.font,
+        fontSize: Config.standfirst[furniture.device].fontSize[furniture.standfirstSize] * scale,
+        lineHeight: Config.standfirst[furniture.device].lineHeight[furniture.standfirstSize] * scale,
+        initialOffset: standfirstOffset,
+        scale
+      });
+    }
+  }
+
   _getImageDataUrl(imageUrl: string) {
     const key = encodeURIComponent(imageUrl);
     const maybeItem = this.imageCache.get(key);
@@ -171,7 +260,7 @@ class CanvasCard {
 
   _getImage(imageUrl: string) {
     return this._getImageDataUrl(imageUrl).then(
-      dataUrl =>
+      (dataUrl: string) =>
         new Promise<HTMLImageElement>(resolve => {
           const image = new Image();
           image.addEventListener("load", _ => resolve(image));
@@ -205,67 +294,7 @@ class CanvasCard {
 
       if(canvasContext){
         this._drawImage({ canvasContext, image });
-
-        const splitHeadline = !furniture.headline
-          ? []
-          : this._splitTextIntoLines({
-              canvasContext,
-              maxWidth: Config.headline[furniture.device].maxWidth * scale,
-              text: furniture.headline,
-              font: Config.headline.font,
-              fontSize: Config.headline[furniture.device].fontSize[furniture.headlineSize] * scale
-            });
-
-        const splitStandfirst = !furniture.standfirst
-          ? []
-          : this._splitTextIntoLines({
-              canvasContext,
-              maxWidth: Config.standfirst[furniture.device].maxWidth * scale,
-              text: furniture.standfirst,
-              font: Config.standfirst.font,
-              fontSize: Config.standfirst[furniture.device].fontSize[furniture.standfirstSize] * scale
-            });
-
-        const headlineHeight =
-          (splitHeadline.length * Config.headline[furniture.device].lineHeight[furniture.headlineSize] +
-            Config.padding) *
-          scale;
-        const standfirstHeight =
-          splitStandfirst.length *
-          Config.standfirst[furniture.device].lineHeight[furniture.standfirstSize] * scale;
-
-        const availableHeight = canvas.height - standfirstHeight - headlineHeight - Config.padding * scale
-
-        canvasContext.fillStyle = furniture.headlineColour;
-
-        if (splitHeadline.length > 0) {
-          const headlineOffset = availableHeight * furniture.position / 100
-
-          this._drawText({
-            canvasContext,
-            lines: splitHeadline,
-            font: Config.headline.font,
-            fontSize: Config.headline[furniture.device].fontSize[furniture.headlineSize] * scale,
-            lineHeight: Config.headline[furniture.device].lineHeight[furniture.headlineSize] * scale,
-            initialOffset: headlineOffset,
-            scale
-          });
-        }
-
-        canvasContext.fillStyle = furniture.standfirstColour;
-
-        if (splitStandfirst.length > 0) {
-          const standfirstOffset = availableHeight * furniture.position / 100 + headlineHeight
-          this._drawText({
-            canvasContext,
-            lines: splitStandfirst,
-            font: Config.standfirst.font,
-            fontSize: Config.standfirst[furniture.device].fontSize[furniture.standfirstSize] * scale,
-            lineHeight: Config.standfirst[furniture.device].lineHeight[furniture.standfirstSize] * scale,
-            initialOffset: standfirstOffset,
-            scale
-          });
-        }
+        this._drawFurniture(canvas, canvasContext, furniture, scale)
       }
     });
   }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -19,7 +19,7 @@ export default {
       fontSize: {
         small: 52,
         medium: 68,
-        large: 130
+        large: 82
       }
     },
     tablet: {

--- a/src/utils/furniture-helpers.ts
+++ b/src/utils/furniture-helpers.ts
@@ -5,15 +5,19 @@ import { Device } from "../enums/device"
 
 export default function(): Furniture {
   return {
-    headline: "",
+    headline: undefined,
     headlineSize: HeadlineSize.Small,
     headlineColour: config.swatches.simple.white,
-    standfirst: "",
+    kicker: undefined,
+    kickerColour: config.swatches.simple.white,
+    standfirst: undefined,
     standfirstSize: StandfirstSize.Small,
     standfirstColour: config.swatches.simple.white,
+    byline: undefined,
+    bylineColour: config.swatches.simple.white,
     position: 0,
     device: Device.Mobile,
-    imageUrl: "",
+    imageUrl: undefined,
   }
 }
 

--- a/src/utils/text-renderer.ts
+++ b/src/utils/text-renderer.ts
@@ -1,0 +1,79 @@
+export class TextRenderer {
+
+  constructor({canvasContext, maxWidth, font, fontSize, lineHeight, scale, padding} :
+    {canvasContext: CanvasRenderingContext2D, maxWidth: number, font: string, fontSize: number, lineHeight: number, scale: number, padding: number}){
+    this.canvasContext = canvasContext;
+    this.maxWidth = maxWidth;
+    this.font = font;
+    this.fontSize = fontSize;
+    this.lineHeight = lineHeight;
+    this.scale = scale;
+    this.padding = padding;
+  }
+
+  canvasContext: CanvasRenderingContext2D;
+  maxWidth: number;
+  font: string;
+  fontSize: number;
+  lineHeight: number;
+  scale: number;
+  padding: number;
+
+  doesTextFit(text: string) {
+    const measure = this.canvasContext.measureText(text);
+    return measure.width < this.maxWidth;
+  }
+
+  splitTextIntoLines(text: string): string[] {
+    this.canvasContext.font = `${this.fontSize}px ${this.font}`;
+
+    const measured = text.split("").reduce(
+      ({ buffer, lines }: {buffer: string, lines: any}, char: string) => {
+        const newBuffer = buffer + char;
+        //Are we on a newline?
+        if (char === "\n") {
+          return { lines: [...lines, buffer], buffer: "" };
+        }
+        //Does the text fit ok?
+        if (this.doesTextFit(newBuffer)) {
+          return { lines: lines, buffer: newBuffer };
+        }
+
+        //Can we split at a space?
+        const lastSpace = newBuffer.lastIndexOf(" ");
+        if (lastSpace !== -1) {
+          const left = newBuffer.substring(0, lastSpace);
+          const right = newBuffer.substring(lastSpace + 1);
+          return {
+            lines: [...lines, left],
+            buffer: right
+          };
+        }
+        return { lines: [...lines, buffer], buffer: char };
+      },
+      { buffer: "", lines: [] }
+    );
+
+    return [...measured.lines, measured.buffer];
+  }
+
+  measureTextWidth(text: string){
+    return this.canvasContext.measureText(text).width;
+  }
+
+  drawText(
+    lines: string[],
+    initialXOffset: number,
+    initialYOffset: number,
+    colour: string
+  ) {
+    this.canvasContext.font = `${this.fontSize}px ${this.font}`;
+    this.canvasContext.fillStyle = colour;
+    lines.forEach((line, i) => {
+      const xOffset = this.padding * this.scale + initialXOffset
+      const yOffset = initialYOffset + this.lineHeight * (i + 1);
+      this.canvasContext.fillText(line, xOffset, yOffset);
+    });
+  }
+
+}


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR provides the ability to set a Kicker and Byline on a card, including the ability to change their colours separately.  It also attempts to improve the UX of the editor by moving form sections into collapsible areas. 

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
A user should be able to setup a combination of Headline, Kicker, Standfirst & Byline in anyway they see fit without visual glitches. In reality we would only expect to see a subset of these combined but we should aim to accommodate all situations.

The UX changes should also make the tool easier to use, especially given the now large number of input options. 

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
The changes to the UX, if not intuitive could cause confusion to the user. There may also be combinations of the various inputs which cause the image to be rendered in a strange or erroneous way.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![CardBuilder](https://user-images.githubusercontent.com/4633246/87134894-3268d900-c291-11ea-846f-159c2ebbb549.gif)

