### PR TITLE
Fixes large font vertical overlap

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -19,7 +19,7 @@ export default {
       fontSize: {
         small: 52,
         medium: 68,
-        large: 130
+        large: 82
       }
     },
     tablet: {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR fixes an issue with the large font size which was causing text to overlap vertically. This issue appears to have been added erroneously in this [PR](https://github.com/guardian/editions-card-builder/pull/25/files).

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
The large font size should now display without any overlap issues. 

## Images
![image](https://user-images.githubusercontent.com/4633246/87287094-98ec3200-c4f1-11ea-9184-23446d5a5ed4.png)
