### PR TITLE
Performance improvements

### DIFF
--- a/src/components/canvas.tsx
+++ b/src/components/canvas.tsx
@@ -47,7 +47,8 @@ class Canvas extends React.Component<CanvasProps, CanvasState> {
       state.card.draw(canvas, props.furniture)
         .then(() => {
           canvas.toBlob( (blob) => props.update(blob || undefined))
-        });
+        })
+        .catch( error =>  console.log(error) );
     }
   }
 

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -256,11 +256,15 @@ class CanvasCard {
 
     this.furniture = furniture;
 
-    var drawCount = ++this.drawCount;
+    if (this.drawCount > 0) {
+      return Promise.reject("already-drawing");
+    }
+
+    this.drawCount++;
 
     return this._getImage(furniture.imageUrl).then(image => {
 
-      if(drawCount != this.drawCount || !this.furniture){
+      if(!this.furniture){
         return Promise.reject();
       }
 
@@ -278,10 +282,13 @@ class CanvasCard {
 
       const canvasContext = canvas.getContext("2d");
 
+
       if(canvasContext){
         this._drawImage({ canvasContext, image });
         this._drawFurniture(canvas, canvasContext, this.furniture, scale)
       }
+
+      this.drawCount--;
     },
     () => this.drawCount--);
   }

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -10,12 +10,12 @@ class CanvasCard {
 
   imageCache: Map<any,any>;
   furniture?: Furniture;
-  drawCount: number;
+  drawing: boolean;
 
   constructor() {
     this.imageCache = new Map();
     this.furniture = undefined;
-    this.drawCount = 0;
+    this.drawing = false;
   }
 
   private _getCanvasDimensions({ deviceWidth, deviceHeight, imageWidth, imageHeight }:
@@ -256,14 +256,13 @@ class CanvasCard {
 
     this.furniture = furniture;
 
-    if (this.drawCount > 0) {
+    if (this.drawing) {
       return Promise.reject("already-drawing");
     }
 
-    this.drawCount++;
+    this.drawing = true;
 
     return this._getImage(furniture.imageUrl).then(image => {
-
       if(!this.furniture){
         return Promise.reject();
       }
@@ -282,15 +281,14 @@ class CanvasCard {
 
       const canvasContext = canvas.getContext("2d");
 
-
       if(canvasContext){
         this._drawImage({ canvasContext, image });
         this._drawFurniture(canvas, canvasContext, this.furniture, scale)
       }
-
-      this.drawCount--;
-    },
-    () => this.drawCount--);
+    })
+    .finally(
+      () => this.drawing = false
+    );
   }
 }
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR is aimed at resolving the various performance issues that are being experienced on the Card Builder. It makes two distinct changes to attempt to improve performance: 
1. It prevents multiple requests for an image by caching a placeholder. If this placeholder is found the draw is rejected as we are loading the image in, and don't want to make a second attempt to load it. The latest furniture is preserved as a property on the CanvasCard class, this ensures no changes are lost. 
2. It adds a draw count, this is used to check if the draw promise is the latest one we care about, otherwise it discards it. This should improve performance by reducing the number of unnecessary draws. 

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
The performance of the tools should be improved for users, allowing them to use the tool more easily. Users have reported delays of around ~10 seconds between inputs and rendering. 

Point 1 especially should improve performance, as a user with a poor internet connection who makes input changes can result in tens of requests for the same image!

## Replication
It is possible to replicate these issues by loading a particularly large image and throttling the network speed in the browsers dev tools. Once the image is loading in, make lots of changes and observe that no duplicated requests for the image are being made.
