### PR TITLE
Use new Source colour names

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,5 +1,11 @@
 import { labs, lifestyle, culture, sport, opinion, news, brand, brandAlt, neutral, specialReport } from '@guardian/src-foundations/palette'
 
+const DARK = 300
+const MAIN = 400
+const BRIGHT = 500
+const PASTEL = 600
+const FADED = 800
+
 export default {
   gridDomain: process.env.GRID_DOMAIN as string,
   dimensions: {
@@ -88,14 +94,14 @@ export default {
 //    We considered merging labs/neutral/special into one entry, but Katy V
 //    was of the opinion that separate entries, even if short, were better.
 
-    brand: (({ dark, main, pastel }) => ({ dark, main, pastel }))(brand),
-    highlight: (({ dark, main }) => ({ dark, main }))(brandAlt),
-    news: (({ dark, main, bright, pastel, faded }) => ({ dark, main, bright, pastel, faded }))(news),
-    opinion: (({ dark, main, bright, pastel, faded }) => ({ dark, main, bright, pastel, faded }))(opinion),
-    sport: (({ dark, main, bright, pastel, faded }) => ({ dark, main, bright, pastel, faded }))(sport),
-    culture: (({ dark, main, bright, pastel, faded }) => ({ dark, main, bright, pastel, faded }))(culture),
-    lifestyle: (({ dark, main, bright, pastel, faded }) => ({ dark, main, bright, pastel, faded }))(lifestyle),
-    labs: (({ dark, main }) => ({ dark, main }))(labs),
+    brand: { dark: brand[DARK], main: brand[MAIN], pastel: brand[PASTEL] },
+    highlight: { dark: brandAlt[DARK], main: brandAlt[MAIN] },
+    news: { dark: news[DARK], main: news[MAIN], bright: news[BRIGHT], pastel: news[PASTEL], faded: news[FADED] },
+    opinion: { dark: opinion[DARK], main: opinion[MAIN], bright: opinion[BRIGHT], pastel: opinion[PASTEL], faded: opinion[FADED] },
+    sport: { dark: sport[DARK], main: sport[MAIN], bright: sport[BRIGHT], pastel: sport[PASTEL], faded: sport[FADED] },
+    culture: { dark: culture[DARK], main: culture[MAIN], bright: culture[BRIGHT], pastel: culture[PASTEL], faded: culture[FADED] },
+    lifestyle: { dark: lifestyle[DARK], main: lifestyle[MAIN], bright: lifestyle[BRIGHT], pastel: lifestyle[PASTEL], faded: lifestyle[FADED], },
+    labs: { dark: labs[DARK], main: labs[MAIN] },
     neutral: { main: neutral["60"] },
     special: { main: specialReport["100"] }
   },


### PR DESCRIPTION
## What does this change?

Source's [global colour names](https://www.theguardian.design/2a1e5182b/p/492a30-light-palette) have changed from semantic words to numbers representing approximate lightness values. This approach was considered more scalable. The word-based names are deprecated and the number-based names have been available for some time.

With 2.0.0 we have decided to declutter the API and delete the old names. The old names will no longer resolve.

With this change, I've preserved the old semantic names here to ensure teams using the card builder don't notice a difference. This change refactors the logic slightly to make the colour assignment more explicit. The alternative would be to do some renaming / destructuring, but I found the resulting code, admittedly DRYer, but more difficult to understand.

**Alternative approach:**

```js

swatches: {
  brand: (({ '300': dark, '400': main, '600': pastel }) => ({ dark, main, pastel }))(brand)
}
```

or even:

```js
const DARK = 300
const MAIN = 400
const PASTEL = 600
// ...
swatches: {
  brand: (({ [DARK]: dark, [MAIN]: main, [PASTEL]: pastel }) => ({ dark, main, pastel }))(brand)
}
```

Happy to discuss 🙂 

## How to test

Nothing should have changed. Hopefully the colours below the swatch selector are still the same!

![Screenshot 2020-07-23 at 15 10 26](https://user-images.githubusercontent.com/5931528/88296486-aa55eb00-ccf6-11ea-9870-113fc3e4e62e.png)

## How can we measure success?

Migration to Source v2.0.0 should be easier