### PR TITLE
Allow byline positioning

### DIFF
--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -9,6 +9,7 @@ import { Furniture } from '../types/furniture';
 import { HeadlineSize, StandfirstSize } from '../enums/size';
 import { Device } from '../enums/device';
 import SizePicker from './size-picker';
+import { BylineLocation } from '../enums/location';
 
 export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: Furniture) => void, updateOriginalImageData: (imageData: object) => void }) => {
   const swatchSelectOptions = Object.keys(Config.swatches)
@@ -66,6 +67,41 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
           <ColourPicker id="kicker" colour={props.furniture?.kickerColour} update={colour => update('kickerColour', colour)}/>
         </Collapsible>
 
+        <Collapsible name="Byline">
+          <label htmlFor="byline">Text</label>
+          <textarea
+            id="byline"
+            name="byline"
+            placeholder="byline..."
+            value={props.furniture?.byline || ""}
+            onChange={event => update('byline', event.target.value)}
+          />
+
+          <fieldset>
+            <legend>Locate under</legend>
+            <input
+              type="radio"
+              id="locationHeadline"
+              name="locationValue"
+              value={BylineLocation.Headline}
+              checked={props.furniture?.bylineLocation == BylineLocation.Headline}
+              onChange={event => update("bylineLocation", event.target.value)}
+            />
+            <label htmlFor="locationHeadline">Headline</label>
+            <input
+              type="radio"
+              id="locationStandfirst"
+              name="locationValue"
+              value={BylineLocation.Standfirst}
+              checked={props.furniture?.bylineLocation == BylineLocation.Standfirst}
+              onChange={event => update("bylineLocation", event.target.value)}
+            />
+            <label htmlFor="locationStandfirst">Standfirst</label>
+          </fieldset>
+
+          <ColourPicker id="byline" colour={props.furniture?.bylineColour} update={colour => update('bylineColour', colour)}/>
+        </Collapsible>
+
         <Collapsible name="Standfirst">
           <label htmlFor="standfirst">Text</label>
           <textarea
@@ -86,18 +122,6 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
             />
           </fieldset>
           <ColourPicker id="standfirst" colour={props.furniture?.standfirstColour} update={colour => update('standfirstColour', colour)}/>
-        </Collapsible>
-
-        <Collapsible name="Byline">
-          <label htmlFor="byline">Text</label>
-          <textarea
-            id="byline"
-            name="byline"
-            placeholder="byline..."
-            value={props.furniture?.byline || ""}
-            onChange={event => update('byline', event.target.value)}
-          />
-          <ColourPicker id="byline" colour={props.furniture?.bylineColour} update={colour => update('bylineColour', colour)}/>
         </Collapsible>
 
         <Collapsible name="Position">

--- a/src/enums/location.ts
+++ b/src/enums/location.ts
@@ -1,0 +1,4 @@
+export enum BylineLocation {
+    Headline = "headline",
+    Standfirst = "standfirst"
+}

--- a/src/types/furniture.d.ts
+++ b/src/types/furniture.d.ts
@@ -1,5 +1,6 @@
 import { Device } from "../enums/device";
 import { HeadlineSize, StandfirstSize } from "../enums/size";
+import { BylineLocation } from "../enums/location";
 
 export interface Furniture {
   device: Device
@@ -14,6 +15,6 @@ export interface Furniture {
   standfirstColour: string
   byline: string | undefined
   bylineColour: string
+  bylineLocation: BylineLocation
   position: number
 }
-

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -167,7 +167,7 @@ class CanvasCard {
       new TextRenderer({
         canvasContext,
         maxWidth: Config.headline[furniture.device].maxWidth * scale,
-        font: Config.standfirst.font,
+        font: Config.byline.underHeadline.font,
         fontSize: Config.headline[furniture.device].fontSize[furniture.headlineSize] * scale,
         lineHeight: Config.headline[furniture.device].lineHeight[furniture.headlineSize] * scale,
         scale: scale,
@@ -176,7 +176,7 @@ class CanvasCard {
       new TextRenderer({
         canvasContext,
         maxWidth: Config.standfirst[furniture.device].maxWidth * scale,
-        font: Config.standfirst.font,
+        font: Config.byline.underStandfirst.font,
         fontSize: Config.standfirst[furniture.device].fontSize[furniture.standfirstSize] * scale,
         lineHeight: Config.standfirst[furniture.device].lineHeight[furniture.standfirstSize] * scale,
         scale: scale,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -74,7 +74,12 @@ export default {
     }
   },
   byline: {
-    font: "Guardian Text Egyptian"
+   underHeadline: {
+      font: "Guardian Headline Light"
+    },
+    underStandfirst: {
+      font: "Guardian Text Egyptian"
+    }
   },
   swatches: {
     simple: {

--- a/src/utils/furniture-helpers.ts
+++ b/src/utils/furniture-helpers.ts
@@ -2,6 +2,7 @@ import config from './config'
 import { Furniture } from '../types/furniture'
 import {  HeadlineSize, StandfirstSize } from "../enums/size"
 import { Device } from "../enums/device"
+import { BylineLocation } from '../enums/location'
 
 export default function(): Furniture {
   return {
@@ -15,9 +16,9 @@ export default function(): Furniture {
     standfirstColour: config.swatches.simple.white,
     byline: undefined,
     bylineColour: config.swatches.simple.white,
+    bylineLocation: BylineLocation.Headline,
     position: 0,
     device: Device.Mobile,
     imageUrl: undefined,
   }
 }
-


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

As stated in the [card](https://trello.com/c/PN5G5KdO/309-provide-multiple-byline-location-options) the users of the editions card builder would like to be able to colocate the byline with either the headline or the standfirst, using the appropriate styling. The byline appearing under the headline should be considered the default. The font for the headline byline is (Guardian Headline) Light and for the standfirst TE32 (Text Egyptian). 

This PR implements these requirements.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Add a byline and choose 'Locate under' + 'Headline' or 'Standfirst' and see the byline change location and font/size.

<!-- ## Images-->
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
