### PR TITLE
Changes the byline text input to be a textarea

### DIFF
--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -125,15 +125,13 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
 
         <Collapsible name="Byline">
           <label htmlFor="byline">Text</label>
-          <input
-            type="text"
+          <textarea
             id="byline"
             name="byline"
             placeholder="byline..."
             value={props.furniture?.byline || ""}
             onChange={event => update('byline', event.target.value)}
           />
-
           <ColourPicker id="byline" colour={props.furniture?.bylineColour} update={colour => update('bylineColour', colour)}/>
         </Collapsible>
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Users would like to be able to use returns in the byline. This is currently not possible with a standard text input. This PR changes the text input to be a text area, allowing users to enter returns.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Loads the card builder and select an image. In the byline section enter some text separate by returns and view the result.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Users can use returns in the byline.
