### PR TITLE
Attempts to fix the to blob race condition

### DIFF
--- a/src/components/canvas.tsx
+++ b/src/components/canvas.tsx
@@ -12,7 +12,6 @@ interface CanvasProps {
 
 interface CanvasState {
   card: CanvasCard
-  drawDebounce: any
   blobDebounce: any
   showCanvas: boolean
 }
@@ -22,7 +21,6 @@ class Canvas extends React.Component<CanvasProps, CanvasState> {
     super(props)
     this.state = {
       card: new CanvasCard(),
-      drawDebounce: debounce(this.draw, 50),
       blobDebounce: debounce(this.updateBlob, 1000),
       showCanvas: false
     }
@@ -34,26 +32,25 @@ class Canvas extends React.Component<CanvasProps, CanvasState> {
   }
 
   componentDidUpdate() {
-    const canvas = this.refs.canvas as HTMLCanvasElement;
-    this.state.drawDebounce.clear();
-    this.state.drawDebounce(canvas, this.state, this.props);
+    this.draw();
     this.setState({showCanvas: true});
   }
 
-  draw(canvas: HTMLCanvasElement, state: CanvasState, props: CanvasProps) {
-    if( props.furniture) {
-      state.blobDebounce.clear();
-      state.card.draw(canvas, props.furniture)
+  draw() {
+    if( this.props.furniture) {
+      const canvas = this.refs.canvas as HTMLCanvasElement;
+      this.state.blobDebounce.clear();
+      this.state.card.draw(canvas, this.props.furniture)
         .then(() => {
-          state.blobDebounce.clear();
-          state.blobDebounce(canvas, props);
+          this.state.blobDebounce.clear();
+          this.state.blobDebounce(canvas, this.props.update);
         })
         .catch( error =>  console.log(error) );
     }
   }
 
-  updateBlob(canvas: HTMLCanvasElement, props: CanvasProps){
-    canvas.toBlob(blob => props.update(blob || undefined))
+  updateBlob(canvas: HTMLCanvasElement, update: (blob? : Blob) => void){
+    canvas.toBlob(blob => update(blob || undefined))
   }
 
   render() {

--- a/src/components/canvas.tsx
+++ b/src/components/canvas.tsx
@@ -13,6 +13,7 @@ interface CanvasProps {
 interface CanvasState {
   card: CanvasCard
   drawDebounce: any
+  blobDebounce: any
   showCanvas: boolean
 }
 
@@ -21,13 +22,10 @@ class Canvas extends React.Component<CanvasProps, CanvasState> {
     super(props)
     this.state = {
       card: new CanvasCard(),
-      drawDebounce: undefined,
+      drawDebounce: debounce(this.draw, 50),
+      blobDebounce: debounce(this.updateBlob, 1000),
       showCanvas: false
     }
-  }
-
-  componentDidMount(){
-    this.setState({drawDebounce: debounce(this.draw, 50)});
   }
 
   shouldComponentUpdate(nextProps: CanvasProps, nextState: CanvasState){
@@ -44,12 +42,18 @@ class Canvas extends React.Component<CanvasProps, CanvasState> {
 
   draw(canvas: HTMLCanvasElement, state: CanvasState, props: CanvasProps) {
     if( props.furniture) {
+      state.blobDebounce.clear();
       state.card.draw(canvas, props.furniture)
         .then(() => {
-          canvas.toBlob( (blob) => props.update(blob || undefined))
+          state.blobDebounce.clear();
+          state.blobDebounce(canvas, props);
         })
         .catch( error =>  console.log(error) );
     }
+  }
+
+  updateBlob(canvas: HTMLCanvasElement, props: CanvasProps){
+    canvas.toBlob(blob => props.update(blob || undefined))
   }
 
   render() {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
After reports of issues by users,  I investigated the problem of uploading/downloading images that didn't match what was displayed on screen. This PR is an attempt to fix a race condition which results in the upload/download options, using an outdated version of the canvas resulting in the uploaded/downloaded image not being the same as the one displayed on screen. 

I believe the cause of this is to be the canvas.toBlob function, it will wait for all pending changes to the canvas to be finished before returning, which may return in no particular order. This could mean the last returned blob is outdated. I was able to identify through console logging rapid text changed and downloading the end result, frequently the image didn't match the current canvas.


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Load an image, makes a rapid set of changes and download the resulting image. The image should always reflect the current canvas. Compare this before and after the PR to see if there is any improvement.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
When a user downloads / uploads a document, they can be confident it is what they're seeing on screen.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
There may be a better solution to this race condition, ~~the current implementation adds a second debounce to attempt to avoid multiple canvas.toBlob calls~~ This implementation swaps the draw debounce with a blob debounce, this should make inputs more responsive but provide an adequate buffer for the canvas toBlob method. 

This changes also adds a delay between seeing changes on screen and being able to download/upload them, which I believe is acceptable.

Happy to demo this to anyone who is interested. 
