### PR TITLE
Moves the to blob call into the header component after a button press

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -9,7 +9,7 @@ import newFurniture from '../utils/furniture-helpers'
 
 
 interface AppState {
-  canvasBlob?: Blob
+  canvas?: HTMLCanvasElement
   furniture?: Furniture
   originalImageData?: object
 }
@@ -19,20 +19,20 @@ class App extends React.Component<any, AppState> {
   constructor(props: any) {
     super(props);
     this.state = {
-      canvasBlob: undefined,
+      canvas: undefined,
       furniture: newFurniture()
     }
   }
 
-  updateCanvasBlob = (newBlob?: Blob) => {
+  updateCanvasBlob = (newCanvas?: HTMLCanvasElement) => {
     this.setState({
-      canvasBlob: newBlob
+      canvas: newCanvas
     })
   }
 
   updateFurniture = (newFurniture: Furniture) => {
     this.setState({
-      canvasBlob: undefined,
+      canvas: undefined,
       furniture: newFurniture
     })
   }
@@ -45,7 +45,7 @@ class App extends React.Component<any, AppState> {
 
   render() {
     return <div>
-      <Header canvasBlob={this.state.canvasBlob} originalImageData={this.state.originalImageData} />
+      <Header canvas={this.state.canvas} originalImageData={this.state.originalImageData} />
       <div className="card-builder">
         <Form furniture={this.state.furniture} updateFurniture={this.updateFurniture} updateOriginalImageData={this.updateOriginalImageData}/>
         <Canvas furniture={this.state.furniture} update={this.updateCanvasBlob}/>

--- a/src/components/canvas.tsx
+++ b/src/components/canvas.tsx
@@ -6,13 +6,12 @@ import CanvasCard from '../utils/canvas'
 import debounce  from 'debounce'
 
 interface CanvasProps {
-  update: (blob? : Blob) => void
+  update: (canvas? : HTMLCanvasElement) => void
   furniture?: Furniture
 }
 
 interface CanvasState {
   card: CanvasCard
-  blobDebounce: any
   showCanvas: boolean
 }
 
@@ -21,7 +20,6 @@ class Canvas extends React.Component<CanvasProps, CanvasState> {
     super(props)
     this.state = {
       card: new CanvasCard(),
-      blobDebounce: debounce(this.updateBlob, 1000),
       showCanvas: false
     }
   }
@@ -39,18 +37,12 @@ class Canvas extends React.Component<CanvasProps, CanvasState> {
   draw() {
     if( this.props.furniture) {
       const canvas = this.refs.canvas as HTMLCanvasElement;
-      this.state.blobDebounce.clear();
       this.state.card.draw(canvas, this.props.furniture)
         .then(() => {
-          this.state.blobDebounce.clear();
-          this.state.blobDebounce(canvas, this.props.update);
+          this.props.update(canvas);
         })
         .catch( error =>  console.log(error) );
     }
-  }
-
-  updateBlob(canvas: HTMLCanvasElement, update: (blob? : Blob) => void){
-    canvas.toBlob(blob => update(blob || undefined))
   }
 
   render() {

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -6,58 +6,65 @@ import config from '../utils/config';
 import { useState } from 'react';
 
 interface HeaderProps {
-  canvasBlob?: Blob
+  canvas?: HTMLCanvasElement
   originalImageData?: object
 }
 
 export default function(props: HeaderProps){
-  const {canvasBlob} = props;
+  const {canvas} = props;
 
   const [gridLink, setGridLink] = useState<string>();
   const [uploading, setUploading] = useState(false);
 
   const uploadImage = () => {
 
-    if(uploading){
+    if(uploading || !canvas){
       return;
     }
 
-    var upload = (canvasBlob: Blob) =>
-      new Promise<ArrayBuffer>(resolve => {
-        setUploading(true);
-        const reader = new FileReader();
-        reader.onloadend = () => resolve(reader.result as ArrayBuffer);
-        reader.readAsArrayBuffer(canvasBlob);
-      })
-      .then(arrayBuffer  =>
-        GridUpload({
-          gridDomain: config.gridDomain,
-          image: new Uint8Array(arrayBuffer),
-          originalImage: props.originalImageData
+    canvas.toBlob( (blob) => {
+      var upload = (canvasBlob: Blob) =>
+        new Promise<ArrayBuffer>(resolve => {
+          setUploading(true);
+          const reader = new FileReader();
+          reader.onloadend = () => resolve(reader.result as ArrayBuffer);
+          reader.readAsArrayBuffer(canvasBlob);
         })
-      )
-      .then(apiResponse => {
-        setUploading(false);
-        const imageUrl = apiResponse.links.find(({ rel }) => rel === "ui:image")?.href;
-        if(imageUrl){
-          setGridLink(imageUrl);
-        }
-      })
-      .catch(error => {
-        setUploading(false);
-        console.error(error);
-        throw error;
-      });
+        .then(arrayBuffer  =>
+          GridUpload({
+            gridDomain: config.gridDomain,
+            image: new Uint8Array(arrayBuffer),
+            originalImage: props.originalImageData
+          })
+        )
+        .then(apiResponse => {
+          setUploading(false);
+          const imageUrl = apiResponse.links.find(({ rel }) => rel === "ui:image")?.href;
+          if(imageUrl){
+            setGridLink(imageUrl);
+          }
+        })
+        .catch(error => {
+          setUploading(false);
+          console.error(error);
+          throw error;
+        });
 
-      if(canvasBlob){
-        setGridLink(undefined);
-        upload(canvasBlob);
-      }
+        if(blob){
+          setGridLink(undefined);
+          upload(blob);
+        }
+
+    })
   }
 
   const downloadImage = () => {
-    if(canvasBlob){
-      download(canvasBlob, "image.png", "image/png");
+    if(canvas){
+      canvas.toBlob( (blob) => {
+        if(blob){
+          download(blob, "image.png", "image/png");
+        }
+      });
     }
   }
 
@@ -70,8 +77,8 @@ export default function(props: HeaderProps){
       </div>
       <div>
         {!!gridLink ? <a href={gridLink} id="gridLink" target="_blank" rel="noopener noreferrer">🖼 Grid</a> : null}
-        <button id="upload" onClick={uploadImage} disabled={!canvasBlob}>{uploading ? "Uploading" : "Upload"}</button>
-        <button id="download" onClick={downloadImage} disabled={!canvasBlob}>Download</button>
+        <button id="upload" onClick={uploadImage} disabled={!canvas}>{uploading ? "Uploading" : "Upload"}</button>
+        <button id="download" onClick={downloadImage} disabled={!canvas}>Download</button>
       </div>
     </header>
   )


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR moves the canvas to blob call into the header component. This has the advantage of only calling to blob when either the upload or download buttons are pressed. This means that the canvas is only turned into an image when requested rather than proactively. This should reduce the number of calls, making it more performant. This may also prevent occasions when an outdated version of image was being used for the upload/download.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Load the card builder, make many changes in rapid succession, download the result. 

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
The downloaded image should always match the rendered one, and the tool should be performant. 
