### PR TITLE
Restore font size work again

### DIFF
--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -8,18 +8,19 @@ import { useState } from 'react'
 import { Furniture } from '../types/furniture';
 import { HeadlineSize, StandfirstSize } from '../enums/size';
 import { Device } from '../enums/device';
+import SizePicker from './size-picker';
 
 export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: Furniture) => void, updateOriginalImageData: (imageData: object) => void }) => {
   const swatchSelectOptions = Object.keys(Config.swatches)
-  const [position, setPostion] = useState("top");
+  const [position, setPosition] = useState("top");
 
   function update(field: string, value: any) {
     const newFurniture = {...props.furniture, [field]: value} as Furniture;
     props.updateFurniture(newFurniture);
   }
 
-  function updatePostion(postion: string, value: any){
-    setPostion(postion);
+  function updatePosition(position: string, value: any){
+    setPosition(position);
     update('position', value);
   }
 
@@ -40,35 +41,12 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
 
           <fieldset>
             <legend>Size</legend>
-            <input
-              type="radio"
-              id="headlineSmall"
-              name="headlineSize"
-              value={HeadlineSize.Small}
-              checked={props.furniture?.headlineSize === HeadlineSize.Small}
-              onChange={event => update('headlineSize', event.target.value)}
+            <SizePicker
+              id="headlineSize"
+              sizes={HeadlineSize}
+              chosenSize={props.furniture?.headlineSize}
+              update={size => update('headlineSize', size)}
             />
-            <label htmlFor="headlineSmall">Small</label>
-
-            <input
-              type="radio"
-              id="headlineMedium"
-              name="headlineSize"
-              value={HeadlineSize.Medium}
-              checked={props.furniture?.headlineSize === HeadlineSize.Medium}
-              onChange={event => update('headlineSize', event.target.value)}
-            />
-            <label htmlFor="headlineMedium">Medium</label>
-
-            <input
-              type="radio"
-              id="headlineLarge"
-              name="headlineSize"
-              value={HeadlineSize.Large}
-              checked={props.furniture?.headlineSize === HeadlineSize.Large}
-              onChange={event => update('headlineSize', event.target.value)}
-            />
-            <label htmlFor="headlineLarge">Large</label>
           </fieldset>
 
           <ColourPicker id="headline" colour={props.furniture?.headlineColour} update={colour => update('headlineColour', colour)}/>
@@ -100,25 +78,12 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
 
           <fieldset>
             <legend>Size</legend>
-            <input
-              type="radio"
-              id="standfirstSmall"
-              name="standfirstSize"
-              value={StandfirstSize.Small}
-              checked={props.furniture?.standfirstSize === StandfirstSize.Small}
-              onChange={event => update('standfirstSize', event.target.value)}
+            <SizePicker
+              id="standfirstSize"
+              sizes={StandfirstSize}
+              chosenSize={props.furniture?.standfirstSize}
+              update={size => update('standfirstSize', size)}
             />
-            <label htmlFor="standfirstSmall">Small</label>
-
-            <input
-              type="radio"
-              id="standfirstMedium"
-              name="standfirstSize"
-              value={StandfirstSize.Medium}
-              checked={props.furniture?.standfirstSize === StandfirstSize.Medium}
-              onChange={event => update('standfirstSize', event.target.value)}
-            />
-            <label htmlFor="standfirstMedium">Medium</label>
           </fieldset>
           <ColourPicker id="standfirst" colour={props.furniture?.standfirstColour} update={colour => update('standfirstColour', colour)}/>
         </Collapsible>
@@ -144,7 +109,7 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
               name="positionValue"
               value="top"
               checked={position == "top"}
-              onChange={event => updatePostion("top", 0)}
+              onChange={event => updatePosition("top", 0)}
             />
             <label htmlFor="positionTop">Top</label>
 
@@ -154,7 +119,7 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
               name="positionValue"
               value="middle"
               checked={position == "middle"}
-              onChange={event => updatePostion("middle", 40)}
+              onChange={event => updatePosition("middle", 40)}
             />
             <label htmlFor="positionMiddle">Middle</label>
             <input
@@ -163,7 +128,7 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
               name="positionValue"
               value="bottom"
               checked={position == "bottom"}
-              onChange={event => updatePostion("bottom", 100)}
+              onChange={event => updatePosition("bottom", 100)}
             />
             <label htmlFor="positionBottom">Bottom</label>
             <br/>
@@ -173,7 +138,7 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
                 id="positionCustom"
                 name="positionValue"
                 checked={position == "custom"}
-                onChange={() => updatePostion("custom", 50)}
+                onChange={() => updatePosition("custom", 50)}
                 value="custom"
               />
               <label htmlFor="positionCustom">Custom</label>
@@ -184,7 +149,7 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
                 value={props.furniture?.position}
                 min="1"
                 max="99"
-                onChange={event => updatePostion("custom", event.target.value)}
+                onChange={event => updatePosition("custom", event.target.value)}
               />
             </div>
 

--- a/src/components/size-picker.tsx
+++ b/src/components/size-picker.tsx
@@ -1,0 +1,30 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/core'
+import { HeadlineSize, StandfirstSize, SizeTypes} from '../enums/size';
+
+export default(props: {
+  id: string,
+  sizes: SizeTypes,
+  chosenSize: HeadlineSize | StandfirstSize | undefined,
+  update: (size: string) => void,
+ }) => {
+  return (
+    <div id={props.id}>
+      {Object.entries(props.sizes).map(([key, value]) => (
+        <span
+          key={`headline${key}`}
+        >
+          <input
+            type="radio"
+            id={`${props.id}_${key}`}
+            name={`${props.id}_${key}`}
+            value={value}
+            checked={props.chosenSize === value}
+            onChange={event => props.update(event.target.value)}
+          />
+          <label htmlFor={`${props.id}_${key}`}>{key}</label>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/enums/size.ts
+++ b/src/enums/size.ts
@@ -1,10 +1,13 @@
 export enum HeadlineSize {
   Small = "small",
   Medium = "medium",
-  Large = "large"
+  Large = "large",
+  XLarge = 'xLarge'
 }
 
 export enum StandfirstSize {
   Small = "small",
   Medium = "medium"
 }
+
+export type SizeTypes = typeof HeadlineSize | typeof StandfirstSize;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,8 +1,8 @@
 @font-face {
   font-family: "Guardian Text Egyptian";
-  src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2)
+  src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2)
     format("woff2"),
-      url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff)
+      url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff)
     format("woff");
   font-weight: 700;
   font-style: normal;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,5 +1,15 @@
 @font-face {
-  font-family: "Guardian Headline Full";
+  font-family: "Guardian Text Egyptian";
+  src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2)
+    format("woff2"),
+      url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff)
+    format("woff");
+  font-weight: 700;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "Guardian Headline Light";
   src: url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Light.woff2)
       format("woff2"),
     url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Light.woff)
@@ -11,7 +21,7 @@
 }
 
 @font-face {
-  font-family: "Guardian Headline Full";
+  font-family: "Guardian Headline Light";
   src: url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-LightItalic.woff2)
       format("woff2"),
     url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-LightItalic.woff)

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -1,7 +1,5 @@
 import Config from "./config";
 import { Furniture } from "../types/furniture";
-import { promises } from "fs";
-import { line } from "@guardian/src-foundations/palette";
 import { TextRenderer } from "./text-renderer"
 
 const PLACEHOLDER = "PLACEHOLDER";
@@ -154,7 +152,7 @@ class CanvasCard {
       padding: Config.padding
     });
 
-    const standfirstAndBylineRenderer = new TextRenderer({
+    const standfirstRenderer = new TextRenderer({
       canvasContext,
       maxWidth: Config.standfirst[furniture.device].maxWidth * scale,
       font: Config.standfirst.font,
@@ -164,11 +162,21 @@ class CanvasCard {
       padding: Config.padding
     });
 
+    const bylineRenderer = new TextRenderer({
+      canvasContext,
+      maxWidth: Config.standfirst[furniture.device].maxWidth * scale,
+      font: Config.byline.font,
+      fontSize: Config.standfirst[furniture.device].fontSize[furniture.standfirstSize] * scale,
+      lineHeight: Config.standfirst[furniture.device].lineHeight[furniture.standfirstSize] * scale,
+      scale: scale,
+      padding: Config.padding
+    });
+
     const kickerAndHeadlineText = `${furniture.kicker ? furniture.kicker + " " : ""}${furniture.headline || ""}`
 
     const splitHeadlineAndKicker = !furniture.headline && !furniture.kicker ? [] : headlineAndKickerRenderer.splitTextIntoLines(kickerAndHeadlineText);
-    const splitStandfirst = !furniture.standfirst ? [] : standfirstAndBylineRenderer.splitTextIntoLines(furniture.standfirst);
-    const splitByline = !furniture.byline ? [] : standfirstAndBylineRenderer.splitTextIntoLines(furniture.byline);
+    const splitStandfirst = !furniture.standfirst ? [] : standfirstRenderer.splitTextIntoLines(furniture.standfirst);
+    const splitByline = !furniture.byline ? [] : bylineRenderer.splitTextIntoLines(furniture.byline);
 
     const headlineHeight = (splitHeadlineAndKicker.length * Config.headline[furniture.device].lineHeight[furniture.headlineSize] + Config.padding) * scale;
     const standfirstHeight = splitStandfirst.length * Config.standfirst[furniture.device].lineHeight[furniture.standfirstSize] * scale;
@@ -193,12 +201,12 @@ class CanvasCard {
 
     if (splitStandfirst.length > 0) {
       const standfirstOffset = availableHeight * furniture.position / 100 + headlineHeight;
-      standfirstAndBylineRenderer.drawText(splitStandfirst, 0, standfirstOffset, furniture.standfirstColour);
+      standfirstRenderer.drawText(splitStandfirst, 0, standfirstOffset, furniture.standfirstColour);
     }
 
     if (splitByline.length > 0) {
       const bylineOffset = availableHeight * furniture.position / 100 + headlineHeight + standfirstHeight;
-      standfirstAndBylineRenderer.drawText(splitByline, 0, bylineOffset, furniture.bylineColour);
+      bylineRenderer.drawText(splitByline, 0, bylineOffset, furniture.bylineColour);
     }
   }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -5,6 +5,8 @@ const MAIN = 400
 const BRIGHT = 500
 const PASTEL = 600
 const FADED = 800
+const headlineLineHeightMultiplier = 1.05;
+const standfirstLineHeightMultiplier = 1.1;
 
 export default {
   gridDomain: process.env.GRID_DOMAIN as string,
@@ -18,37 +20,41 @@ export default {
     mobile: {
       maxWidth: 420,
       lineHeight: {
-        small: 56,
-        medium: 70,
-        large: 84
+        small: 52 * headlineLineHeightMultiplier,
+        medium: 68 * headlineLineHeightMultiplier,
+        large: 84 * headlineLineHeightMultiplier,
+        xLarge: 100 * headlineLineHeightMultiplier
       },
       fontSize: {
         small: 52,
         medium: 68,
-        large: 82
+        large: 84,
+        xLarge: 100
       }
     },
     tablet: {
       maxWidth: 648,
       lineHeight: {
-        small: 86,
-        medium: 114,
-        large: 200
+        small: 80 * headlineLineHeightMultiplier,
+        medium: 105 * headlineLineHeightMultiplier,
+        large: 128 * headlineLineHeightMultiplier,
+        xLarge: 180 * headlineLineHeightMultiplier
       },
       fontSize: {
         small: 80,
         medium: 105,
-        large: 180
+        large: 128,
+        xLarge: 180
       }
     }
   },
   standfirst: {
-    font: "Guardian Headline Full",
+    font: "Guardian Text Egyptian",
     mobile: {
       maxWidth: 350,
       lineHeight: {
-        small: 36,
-        medium: 40
+        small: 28 * standfirstLineHeightMultiplier,
+        medium: 32 * standfirstLineHeightMultiplier
       },
       fontSize: {
         small: 28,
@@ -58,14 +64,17 @@ export default {
     tablet: {
       maxWidth: 572,
       lineHeight: {
-        small: 50,
-        medium: 59
+        small: 43 * standfirstLineHeightMultiplier,
+        medium: 49 * standfirstLineHeightMultiplier
       },
       fontSize: {
         small: 43,
         medium: 49
       }
     }
+  },
+  byline: {
+    font: "Guardian Text Egyptian"
   },
   swatches: {
     simple: {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR restores the font sizes changes which were reverted, pending a discussion. The original PR can be found [here](https://github.com/guardian/editions-card-builder/pull/60). They have now been approved, with a small change, requiring that the standfirst and byline should not be bold by default. The option for a user to set the font weight to bold will be coming in a later PR.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
To test the standfirst font change, add an image, add some standfirst/byline text and observe the font should have a regular weight.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Users have the correct font options available to them.

**NB** Please forgive the typo in the branch name

