### PR TITLE
Fix text overlap

### DIFF
--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -190,7 +190,7 @@ class CanvasCard {
     const splitByline = !furniture.byline ? [] : bylineRenderer.splitTextIntoLines(furniture.byline);
 
     const paddingHeight = Config.padding * scale;
-    const headlineHeight = splitHeadlineAndKicker.length * headlineAndKickerRenderer.lineHeight + paddingHeight;
+    const headlineHeight = splitHeadlineAndKicker.length * headlineAndKickerRenderer.lineHeight;
     const standfirstHeight = splitStandfirst.length * standfirstRenderer.lineHeight;
     const bylineHeight = splitByline.length * bylineRenderer.lineHeight;
 
@@ -202,7 +202,7 @@ class CanvasCard {
     }
     else if (!!furniture.headline) {
       const splitHeadline = headlineAndKickerRenderer.splitTextIntoLines(furniture.headline);
-      const headlineOffset = + paddingHeight + availableHeight * furniture.position / 100;
+      const headlineOffset = availableHeight * furniture.position / 100;
       headlineAndKickerRenderer.drawText(splitHeadline, 0, headlineOffset, furniture.headlineColour);
     }
     else if(!!furniture.kicker) {

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -190,7 +190,7 @@ class CanvasCard {
     const splitByline = !furniture.byline ? [] : bylineRenderer.splitTextIntoLines(furniture.byline);
 
     const paddingHeight = Config.padding * scale;
-    const headlineHeight = splitHeadlineAndKicker.length * headlineAndKickerRenderer.lineHeight;
+    const headlineHeight = splitHeadlineAndKicker.length * headlineAndKickerRenderer.lineHeight + paddingHeight;
     const standfirstHeight = splitStandfirst.length * standfirstRenderer.lineHeight;
     const bylineHeight = splitByline.length * bylineRenderer.lineHeight;
 
@@ -202,7 +202,7 @@ class CanvasCard {
     }
     else if (!!furniture.headline) {
       const splitHeadline = headlineAndKickerRenderer.splitTextIntoLines(furniture.headline);
-      const headlineOffset = availableHeight * furniture.position / 100;
+      const headlineOffset = + paddingHeight + availableHeight * furniture.position / 100;
       headlineAndKickerRenderer.drawText(splitHeadline, 0, headlineOffset, furniture.headlineColour);
     }
     else if(!!furniture.kicker) {

--- a/src/utils/text-renderer.ts
+++ b/src/utils/text-renderer.ts
@@ -69,6 +69,7 @@ export class TextRenderer {
   ) {
     this.canvasContext.font = `${this.fontSize}px ${this.font}`;
     this.canvasContext.fillStyle = colour;
+    this.canvasContext.textBaseline = "bottom";
     lines.forEach((line, i) => {
       const xOffset = this.padding * this.scale + initialXOffset
       const yOffset = initialYOffset + this.lineHeight * (i + 1);


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR fixes the text overlap by setting the [text baseline](https://www.w3schools.com/tags/canvas_textbaseline.asp) option to bottom. This will mean that descenders no longer go bellow the pixel position. 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Select an image, add descenders and ascenders to the the headline and standfirst at various heights and font sizes. 

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
If there is never any overlap between lines.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
This change make a slight difference to spaces between lines which may be undesirable.

## Images

Before:
![image](https://user-images.githubusercontent.com/4633246/89889012-ddd6b780-dbc8-11ea-8bea-0b43ca05420f.png)

After:
![image](https://user-images.githubusercontent.com/4633246/89889149-18d8eb00-dbc9-11ea-84c4-457d3adae2ee.png)
