### PR TITLE
Fixes the top offset of text

### DIFF
--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -88,7 +88,7 @@ class CanvasCard {
     );
   }
 
-  private _drawKickerAndHeadline(headlineRenderer: TextRenderer, canvas: HTMLCanvasElement, furniture: Furniture, scale: number, availableHeight: number){
+  private _drawKickerAndHeadline(headlineRenderer: TextRenderer, canvas: HTMLCanvasElement, furniture: Furniture, scale: number, availableHeight: number, initialHeight: number){
     //Split kicker into multiple lines
     const splitKicker = headlineRenderer.splitTextIntoLines(furniture.kicker as string);
     const lastKickerLine = splitKicker[splitKicker.length - 1];
@@ -110,12 +110,12 @@ class CanvasCard {
       const lineCount = splitKicker.length + splitHeadlineAndKicker.length - 1;
       //render all lines but last
       if(splitKicker.length > 1){
-        const kickerOffset = availableHeight * furniture.position / 100;
+        const kickerOffset = initialHeight;
         headlineRenderer.drawText(splitKicker.slice(0, splitKicker.length - 1), 0, kickerOffset, furniture.kickerColour);
       }
 
       //Render last kicker line
-      const lastKickerOfest = availableHeight * furniture.position / 100 + (lineHeight * (splitKicker.length - 1));
+      const lastKickerOfest = initialHeight + (lineHeight * (splitKicker.length - 1));
       headlineRenderer.drawText([lastKickerLine], 0, lastKickerOfest, furniture.kickerColour);
 
       //Render rest of rest of first headline
@@ -124,7 +124,7 @@ class CanvasCard {
 
       //Render rest of headline lines
       if(splitHeadlineAndKicker.length > 1) {
-        const headlineOffset = availableHeight * furniture.position / 100 + (lineHeight * splitKicker.length);
+        const headlineOffset = initialHeight + (lineHeight * splitKicker.length);
         headlineRenderer.drawText(splitHeadlineAndKicker.slice(1, splitHeadlineAndKicker.length), 0, headlineOffset, furniture.headlineColour);
       }
     }
@@ -132,11 +132,11 @@ class CanvasCard {
     else {
       const lineCount = splitKicker.length + splitHeadlineAndKicker.length - 1;
       //Render kicker lines
-      const kickerOffset = availableHeight * furniture.position / 100;
+      const kickerOffset = initialHeight;
       headlineRenderer.drawText(splitKicker, 0, kickerOffset, furniture.kickerColour);
 
       //Render headline lines
-      const headlineOffset = availableHeight * furniture.position / 100 + (lineHeight * splitKicker.length);
+      const headlineOffset = initialHeight + (lineHeight * splitKicker.length);
       headlineRenderer.drawText(splitHeadlineAndKicker.slice(1, splitHeadlineAndKicker.length), 0, headlineOffset, furniture.headlineColour);
     }
   }
@@ -194,32 +194,33 @@ class CanvasCard {
     const standfirstHeight = splitStandfirst.length * standfirstRenderer.lineHeight;
     const bylineHeight = splitByline.length * bylineRenderer.lineHeight;
 
-    const availableHeight = canvas.height - bylineHeight - standfirstHeight - headlineHeight - paddingHeight;
+    const availableHeight = canvas.height - bylineHeight - standfirstHeight - headlineHeight - (paddingHeight * 2);
+    const initialHeight = availableHeight * furniture.position / 100 + paddingHeight;
 
 
     if(!!furniture.headline && !!furniture.kicker){
-      this._drawKickerAndHeadline(headlineAndKickerRenderer, canvas, furniture, scale, availableHeight);
+      this._drawKickerAndHeadline(headlineAndKickerRenderer, canvas, furniture, scale, availableHeight, initialHeight);
     }
     else if (!!furniture.headline) {
       const splitHeadline = headlineAndKickerRenderer.splitTextIntoLines(furniture.headline);
-      const headlineOffset = availableHeight * furniture.position / 100;
+      const headlineOffset = initialHeight;
       headlineAndKickerRenderer.drawText(splitHeadline, 0, headlineOffset, furniture.headlineColour);
     }
     else if(!!furniture.kicker) {
       const splitKicker = headlineAndKickerRenderer.splitTextIntoLines(furniture.kicker);
-      const kickerOffset = availableHeight * furniture.position / 100;
+      const kickerOffset = initialHeight;
       headlineAndKickerRenderer.drawText(splitKicker, 0, kickerOffset, furniture.kickerColour);
     }
 
     if (splitStandfirst.length > 0) {
       const additionalOffset = furniture.bylineLocation == BylineLocation.Headline ? bylineHeight : 0;
-      const standfirstOffset = availableHeight * furniture.position / 100 + headlineHeight + paddingHeight + additionalOffset;
+      const standfirstOffset = initialHeight + headlineHeight + paddingHeight + additionalOffset;
       standfirstRenderer.drawText(splitStandfirst, 0, standfirstOffset, furniture.standfirstColour);
     }
 
     if (splitByline.length > 0) {
       const additionalOffset = furniture.bylineLocation == BylineLocation.Standfirst ? standfirstHeight + paddingHeight : 0;
-      const bylineOffset = availableHeight * furniture.position / 100 + headlineHeight + additionalOffset;
+      const bylineOffset = initialHeight + headlineHeight + additionalOffset;
       bylineRenderer.drawText(splitByline, 0, bylineOffset, furniture.bylineColour);
     }
   }

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -194,7 +194,7 @@ class CanvasCard {
     const standfirstHeight = splitStandfirst.length * standfirstRenderer.lineHeight;
     const bylineHeight = splitByline.length * bylineRenderer.lineHeight;
 
-    const availableHeight = canvas.height - bylineHeight - standfirstHeight - headlineHeight - (paddingHeight * 2);
+    const availableHeight = canvas.height - bylineHeight - standfirstHeight - headlineHeight - (paddingHeight * 3);
     const initialHeight = availableHeight * furniture.position / 100 + paddingHeight;
 
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR fixes the top offset of text by adding some additional padding. This issue was introduced in a previous PR which adjusted the text baseline, causing all text to be rendered slightly higher.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Select an image, enter some text, observe the top offset of the text.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
The text is rendered in the correct position.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
Before: 
![image](https://user-images.githubusercontent.com/4633246/89906127-e5a35580-dbe2-11ea-86e4-092c03ae2882.png)

After:
![image](https://user-images.githubusercontent.com/4633246/89905719-6a41a400-dbe2-11ea-8c05-499a26b32466.png)

