### PR TITLE
Adds the ability to select the standfirst weight

### DIFF
--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -10,6 +10,7 @@ import { HeadlineSize, StandfirstSize } from '../enums/size';
 import { Device } from '../enums/device';
 import SizePicker from './size-picker';
 import { BylineLocation } from '../enums/location';
+import { FontWeight } from '../enums/font-weight';
 
 export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: Furniture) => void, updateOriginalImageData: (imageData: object) => void }) => {
   const swatchSelectOptions = Object.keys(Config.swatches)
@@ -121,6 +122,29 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
               update={size => update('standfirstSize', size)}
             />
           </fieldset>
+
+          <fieldset>
+            <legend>Weight</legend>
+            <input
+              type="radio"
+              id="regularStandfirst"
+              name="standfirstWeight"
+              value={FontWeight.Regular}
+              checked={props.furniture?.standfirstWeight == FontWeight.Regular}
+              onChange={event => update("standfirstWeight", event.target.value)}
+            />
+            <label htmlFor="regularStandfirst">Regular</label>
+            <input
+              type="radio"
+              id="boldStandfirst"
+              name="standfirstWeight"
+              value={FontWeight.Bold}
+              checked={props.furniture?.standfirstWeight == FontWeight.Bold}
+              onChange={event => update("standfirstWeight", event.target.value)}
+            />
+            <label htmlFor="boldStandfirst">Bold</label>
+          </fieldset>
+
           <ColourPicker id="standfirst" colour={props.furniture?.standfirstColour} update={colour => update('standfirstColour', colour)}/>
         </Collapsible>
 

--- a/src/enums/font-weight.ts
+++ b/src/enums/font-weight.ts
@@ -1,0 +1,5 @@
+export enum FontWeight {
+  Light = "300",
+  Regular = "400",
+  Bold = "700",
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4,6 +4,16 @@
     format("woff2"),
       url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff)
     format("woff");
+  font-weight: 400;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "Guardian Text Egyptian";
+  src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2)
+    format("woff2"),
+      url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff)
+    format("woff");
   font-weight: 700;
   font-style: normal;
 }

--- a/src/types/furniture.d.ts
+++ b/src/types/furniture.d.ts
@@ -1,6 +1,7 @@
 import { Device } from "../enums/device";
 import { HeadlineSize, StandfirstSize } from "../enums/size";
 import { BylineLocation } from "../enums/location";
+import { FontWeight } from "../enums/font-weight";
 
 export interface Furniture {
   device: Device
@@ -13,6 +14,7 @@ export interface Furniture {
   standfirst: string | undefined
   standfirstSize: StandfirstSize
   standfirstColour: string
+  standfirstWeight: FontWeight
   byline: string | undefined
   bylineColour: string
   bylineLocation: BylineLocation

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -2,6 +2,7 @@ import Config from "./config";
 import { Furniture } from "../types/furniture";
 import { TextRenderer } from "./text-renderer"
 import { BylineLocation } from "../enums/location";
+import { FontWeight } from "../enums/font-weight";
 
 const PLACEHOLDER = "PLACEHOLDER";
 
@@ -150,7 +151,8 @@ class CanvasCard {
       fontSize: Config.headline[furniture.device].fontSize[furniture.headlineSize] * scale,
       lineHeight: Config.headline[furniture.device].lineHeight[furniture.headlineSize] * scale,
       scale: scale,
-      padding: Config.padding
+      padding: Config.padding,
+      weight: FontWeight.Bold
     });
 
     const standfirstRenderer = new TextRenderer({
@@ -160,7 +162,8 @@ class CanvasCard {
       fontSize: Config.standfirst[furniture.device].fontSize[furniture.standfirstSize] * scale,
       lineHeight: Config.standfirst[furniture.device].lineHeight[furniture.standfirstSize] * scale,
       scale: scale,
-      padding: Config.padding
+      padding: Config.padding,
+      weight: furniture.standfirstWeight
     });
 
     const bylineRenderer = furniture.bylineLocation == BylineLocation.Headline ?
@@ -171,7 +174,8 @@ class CanvasCard {
         fontSize: Config.headline[furniture.device].fontSize[furniture.headlineSize] * scale,
         lineHeight: Config.headline[furniture.device].lineHeight[furniture.headlineSize] * scale,
         scale: scale,
-        padding: Config.padding
+        padding: Config.padding,
+        weight: FontWeight.Light
       }) :
       new TextRenderer({
         canvasContext,
@@ -180,7 +184,8 @@ class CanvasCard {
         fontSize: Config.standfirst[furniture.device].fontSize[furniture.standfirstSize] * scale,
         lineHeight: Config.standfirst[furniture.device].lineHeight[furniture.standfirstSize] * scale,
         scale: scale,
-        padding: Config.padding
+        padding: Config.padding,
+        weight: FontWeight.Regular
       }) ;
 
     const kickerAndHeadlineText = `${furniture.kicker ? furniture.kicker + " " : ""}${furniture.headline || ""}`

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,6 +1,7 @@
 import { labs, lifestyle, culture, sport, opinion, news, brand, brandAlt, neutral, specialReport } from '@guardian/src-foundations/palette'
 
-document.fonts.load("52px  Guardian Headline Light");
+document.fonts.load("52px Guardian Headline Light");
+document.fonts.load("700 28px Guardian Text Egyptian");
 
 const DARK = 300
 const MAIN = 400

--- a/src/utils/furniture-helpers.ts
+++ b/src/utils/furniture-helpers.ts
@@ -3,6 +3,7 @@ import { Furniture } from '../types/furniture'
 import {  HeadlineSize, StandfirstSize } from "../enums/size"
 import { Device } from "../enums/device"
 import { BylineLocation } from '../enums/location'
+import { FontWeight } from '../enums/font-weight'
 
 export default function(): Furniture {
   return {
@@ -14,6 +15,7 @@ export default function(): Furniture {
     standfirst: undefined,
     standfirstSize: StandfirstSize.Small,
     standfirstColour: config.swatches.simple.white,
+    standfirstWeight: FontWeight.Regular,
     byline: undefined,
     bylineColour: config.swatches.simple.white,
     bylineLocation: BylineLocation.Headline,

--- a/src/utils/text-renderer.ts
+++ b/src/utils/text-renderer.ts
@@ -1,7 +1,9 @@
+import { FontWeight } from "../enums/font-weight";
+
 export class TextRenderer {
 
-  constructor({canvasContext, maxWidth, font, fontSize, lineHeight, scale, padding} :
-    {canvasContext: CanvasRenderingContext2D, maxWidth: number, font: string, fontSize: number, lineHeight: number, scale: number, padding: number}){
+  constructor({canvasContext, maxWidth, font, fontSize, lineHeight, scale, padding, weight} :
+    {canvasContext: CanvasRenderingContext2D, maxWidth: number, font: string, fontSize: number, lineHeight: number, scale: number, padding: number, weight: string }){
     this.canvasContext = canvasContext;
     this.maxWidth = maxWidth;
     this.font = font;
@@ -9,6 +11,7 @@ export class TextRenderer {
     this.lineHeight = lineHeight;
     this.scale = scale;
     this.padding = padding;
+    this.weight = weight;
   }
 
   canvasContext: CanvasRenderingContext2D;
@@ -18,6 +21,7 @@ export class TextRenderer {
   lineHeight: number;
   scale: number;
   padding: number;
+  weight: string;
 
   doesTextFit(text: string) {
     const measure = this.canvasContext.measureText(text);
@@ -67,7 +71,7 @@ export class TextRenderer {
     initialYOffset: number,
     colour: string
   ) {
-    this.canvasContext.font = `${this.fontSize}px ${this.font}`;
+    this.canvasContext.font = `${this.weight} ${this.fontSize}px ${this.font}`;
     this.canvasContext.fillStyle = colour;
     this.canvasContext.textBaseline = "bottom";
     lines.forEach((line, i) => {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR adds the ability to set the font weight of the standfirst text. A [requirement for Australia editions](https://trello.com/c/y6yxpZzJ/340-ability-to-select-the-font-weight-of-the-standfirst).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Select an image, enter some text into the various sections. Experiment with changing the standfirst font weight. 

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Users are able to set the standfirst font weight appropriately.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![StandfirstWeight](https://user-images.githubusercontent.com/4633246/90384714-eb34eb80-e079-11ea-8e03-bb25616868c0.gif)

