### PR TITLE
Increase height of mobile cards to 1.8x width

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -14,7 +14,7 @@ const standfirstLineHeightMultiplier = 1.1;
 export default {
   gridDomain: process.env.GRID_DOMAIN as string,
   dimensions: {
-    mobile: [525, 810],
+    mobile: [525, 945],
     tablet: [975, 1088]
   },
   padding: 10,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -14,7 +14,7 @@ const standfirstLineHeightMultiplier = 1.1;
 export default {
   gridDomain: process.env.GRID_DOMAIN as string,
   dimensions: {
-    mobile: [525, 945],
+    mobile: [525, 945], // This is the ratio of an iPhone 5S, the narrowest screen we tolerate
     tablet: [975, 1088]
   },
   padding: 10,


### PR DESCRIPTION
## What does this change?
This modifies the height of mobile cards, increasing it to 945px. This is because on phones like the iPhone 5s, due to the narrow screen size cards are much more 'rectangular' than other phone types -so we need a cover card that is almost twice as long as it is high. My calculation for this new height is 1.8x the width, which I got from looking at the iPhone 5s card width/height ratio. 

A second piece of work would be great to do, which is to show a 'safe area' line indicating which parts of an image might be cropped. This should be at 1.3x the width (based off the iphone 11 pro max - a rather wide phone...).

The issue this solves is illustrated below. Lots of background design work can be seen in [figma](https://www.figma.com/file/AgfOrrLI78asahmA3Z9Env/AUS%2FUS-xtra-designs?node-id=1326%3A803)

<img width="818" alt="Screenshot 2020-08-19 at 12 59 04" src="https://user-images.githubusercontent.com/3606555/90632204-f162cd80-e21b-11ea-97db-280481d7a165.png">


## How to test
I'm not sure - is there a CODE environment? What we would need to do is:

 - generate an image
 - load into an edition on fronts CODE.
 - test in lots of simulators



## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->]

We can say goodbye to ugly whitespace
<img width="304" alt="Screenshot 2020-08-19 at 11 49 38" src="https://user-images.githubusercontent.com/3606555/90632344-2707b680-e21c-11ea-8c0c-f2959b7264bc.png">


## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
The main risk is that, without the 'safe area' work, we will now have an image that is 945 pixels tall, but which could be cropped to ~682 pixels tall on the device. There is therefore an increased risk of chopping people in half or chopping through any overlay text that is added. Even if nothing is chopped up, the 'focus' of the image could end up in the wrong place. Fortunately we have an editorial team working on these who do test them on different devices, but we should try to make it as easy for them as possible.

Otherwise I *think* this is fairly safe as the editions app will happily crop away at any excess height it doesn't want to deal with. I'm not concerned about the increased file size of these images as we don't use so many cover cards in each issue.
