### PR TITLE
Revert "Increase height of mobile cards to 1.8x width"

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -14,7 +14,7 @@ const standfirstLineHeightMultiplier = 1.1;
 export default {
   gridDomain: process.env.GRID_DOMAIN as string,
   dimensions: {
-    mobile: [525, 945], // This is the ratio of an iPhone 5S, the narrowest screen we tolerate
+    mobile: [525, 810],
     tablet: [975, 1088]
   },
   padding: 10,


### PR DESCRIPTION
Reverts guardian/editions-card-builder#77 as it created problems for the production team