### PR TITLE
Switches the blob mime type to be JPEG instead of PNG

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -23,10 +23,12 @@ export default function(props: HeaderProps){
       return;
     }
 
-    canvas.toBlob( (blob) => {
+    setUploading(true);
+
+    convertCanvasToBlob(canvas, (blob) => {
       var upload = (canvasBlob: Blob) =>
         new Promise<ArrayBuffer>(resolve => {
-          setUploading(true);
+
           const reader = new FileReader();
           reader.onloadend = () => resolve(reader.result as ArrayBuffer);
           reader.readAsArrayBuffer(canvasBlob);
@@ -66,12 +68,20 @@ export default function(props: HeaderProps){
     }
 
     setDownloading(true);
-    canvas.toBlob( (blob) => {
+
+    convertCanvasToBlob(canvas, (blob) => {
       if(blob){
-        download(blob, "image.png", "image/png");
+        download(blob, "image.jpeg", "image/jpeg");
       }
       setDownloading(false);
     });
+  }
+
+  const convertCanvasToBlob = (canvas: HTMLCanvasElement, callback: BlobCallback) =>
+  {
+    const mimeType = "image/jpeg";
+    const quality = 0.95;
+    canvas.toBlob(callback, mimeType, quality);
   }
 
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR attempts to reduce the wait times for uploads by reducing the upload image file size. 

This was originally reported by users experiencing long wait times on uploads, especially when they have poorer connections. 

In my testing I have found uploaded images sizes of previously 35mb can be reduced to 6mb. [Before](https://media.test.dev-gutools.co.uk/images/f8d750990175623367a42386ceff5302d94f2c7c) and [after](https://media.test.dev-gutools.co.uk/images/9a8463008046d293ebe80f359e86e090d437af89).

More details can be found on the [trello card](https://trello.com/c/PwXHe1Z9/361-reduce-upload-image-file-size).

**NB** The upload button was being enabled after the blob conversion, which can take some time. Moving this to before the conversion should improve the UX for the upload button.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Select a large image, makes changes, upload the image.
The image quality should be maintained but the file size and upload time should be reduced.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Changing the image format from lossless could result in reduced image quality.
