### PR TITLE
Change collection target to UK Daily Edition

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -124,7 +124,7 @@ export default {
   },
   upload: {
     labels: ["edition-cover-card"],
-    collections: ["iPad Daily Edition"],
+    collections: ["UK Daily Edition"],
     metadataToCopy: [
       "credit",
       "description",


### PR DESCRIPTION
## What does this change?

Changes the collection this tool tags generated images with from `iPad Daily Edition` to `UK Daily Edition`, as requested by Edition staff.

## How to test

Does the tool add generated images to the correct collection?

Tested locally with CODE Grid.

## How can we measure success?

As above.
