### PR TITLE
Revert "Increase mobile ratio to 1.7 "

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -14,7 +14,7 @@ const standfirstLineHeightMultiplier = 1.1;
 export default {
   gridDomain: process.env.GRID_DOMAIN as string,
   dimensions: {
-    mobile: [525, 893], // this is a 1.7 aspect ratio aimed to fit iphone 5s/s3 - our tallest devices
+    mobile: [525, 810],
     tablet: [975, 1088]
   },
   padding: 10,


### PR DESCRIPTION
Sorry for the repeated PRs on this! Reverts guardian/editions-card-builder#81 as it's too severe a crop unfortunately - it results in too great a diff between the images in the grid. Some changes in the grid will be required first
