### PR TITLE
Add workflow_dispatch github actions trigger.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,5 +1,6 @@
 name: CD
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
-on: pull_request
+on:
+  workflow_dispatch:
+  pull_request:
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this change?
Adds the [workflow_dispatch](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) trigger to make it possible to manually run CI/CD

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Go into the [github actions console](https://github.com/guardian/editions-card-builder/actions) then select a branch and run the action on that branch.

## How can we measure success?
Being able to deploy arbitrary branches to PROD, re run CI/CD without having to push code changes. 

## Have we considered potential risks?
It makes it easier to put a development branch on PROD, so should be used with caution. However, this behaviour is already possible via the github api so let's put it in a nice UI!

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
