### PR TITLE
use grid-client for Grid crop validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -938,6 +938,18 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
+    "@guardian/grid-client": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@guardian/grid-client/-/grid-client-1.1.1.tgz",
+      "integrity": "sha512-pNZhe1/9mwvOqkcT5yOYTZdrXY+qgoEfjjl6ixw13020MOXmO9LoSDnJVqSjpfN9DH/WhpJ82pxLCIq6i5xEhQ==",
+      "requires": {
+        "fp-ts": "^2.8.2",
+        "io-ts": "^2.2.10",
+        "io-ts-types": "^0.5.10",
+        "monocle-ts": "^2.3.3",
+        "newtype-ts": "^0.3.4"
+      }
+    },
     "@guardian/src-foundations": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@guardian/src-foundations/-/src-foundations-1.7.0.tgz",
@@ -3317,6 +3329,11 @@
         "mime-types": "^2.1.12"
       }
     },
+    "fp-ts": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.8.2.tgz",
+      "integrity": "sha512-YKLBW75Rp+L9DuY1jr7QO6mZLTmJjy7tOqSAMcB2q2kBomqLjBMyV7dotpcnZmUYY6khMsfgYWtPbUDOFcNmkA=="
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -4361,6 +4378,16 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "io-ts": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.10.tgz",
+      "integrity": "sha512-WHx5jJe7hPpc6JoSIVbD+Xn6tYqe3cRvNpX24d8Wi15/kxhRWa8apo0Gzag6Xg99sCNY9OHKylw/Vhv0JAbNPQ=="
+    },
+    "io-ts-types": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.11.tgz",
+      "integrity": "sha512-BqWYAvcSOxnKWIAYAcqF6nS+zhWRb6W+oezF2FzFt8+5a6b8PHNXmbOiV3MwRDY1G6FIctMo71QtIrExLT7LCQ=="
+    },
     "is-absolute-url": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
@@ -5058,6 +5085,11 @@
         }
       }
     },
+    "monocle-ts": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/monocle-ts/-/monocle-ts-2.3.3.tgz",
+      "integrity": "sha512-pcQyauWO2vapxyZgbhTd73Dv8TmTELx1rL81bvrtPO2sUYTi1MIHmw3j/iMyeNaJwTmnGNAjqJpYV8Gq1Eu68g=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -5089,6 +5121,11 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
+    },
+    "newtype-ts": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/newtype-ts/-/newtype-ts-0.3.4.tgz",
+      "integrity": "sha512-lFJnWAt0oXX1j1ErNy9RU5+FPNtVyzugHW2MchaaMiOeeS9LEmqAAOqyHPFQ0Uw895jStSYGSCslrByzYxFJYQ=="
     },
     "nice-try": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/guardian/editions-card-builder#readme",
   "dependencies": {
     "@emotion/core": "^10.0.34",
+    "@guardian/grid-client": "^1.1.1",
     "@guardian/src-foundations": "^1.5.0",
     "@types/css-font-loading-module": "0.0.4",
     "@types/debounce": "^1.2.0",

--- a/src/components/image-select.tsx
+++ b/src/components/image-select.tsx
@@ -3,6 +3,8 @@ import { jsx } from '@emotion/core'
 import * as React from 'react';
 import config from "../utils/config"
 import Modal from './modal';
+import {IframePostMessageService} from "@guardian/grid-client"
+import {Reporter} from "@guardian/grid-client/lib/utils"
 
 interface GridModalProps {
   updateImageUrl: (imageUrl: string) => void
@@ -50,23 +52,20 @@ class ImageSelect extends React.Component<GridModalProps, GridModalState> {
       return;
     }
 
-    const data = event.data;
+    const postMessageService = new IframePostMessageService(event, Reporter.default)
 
-    if (!data) {
+    if(!postMessageService.isValid) {
       return;
     }
 
-    if (!this.validMessage(data)) {
-      return;
-    }
+    const imageUrl: URL = postMessageService.highestQualityImageURL!;
 
-    const imageUrl = event.data.crop.data.master.secureUrl;
     this.setState({
-      imageId: event.data.image.data.id as string
+      imageId: postMessageService.imageId!
     });
 
     this.closeModal();
-    this.props.updateImageUrl(imageUrl);
+    this.props.updateImageUrl(imageUrl.toString());
     this.props.updateOriginalImageData(event.data.image);
   };
 

--- a/src/components/image-select.tsx
+++ b/src/components/image-select.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import config from "../utils/config"
 import Modal from './modal';
 import {IframePostMessageService} from "@guardian/grid-client"
-import {Reporter} from "@guardian/grid-client/lib/utils"
 
 interface GridModalProps {
   updateImageUrl: (imageUrl: string) => void
@@ -52,7 +51,7 @@ class ImageSelect extends React.Component<GridModalProps, GridModalState> {
       return;
     }
 
-    const postMessageService = new IframePostMessageService(event, Reporter.default)
+    const postMessageService = new IframePostMessageService(event)
 
     if(!postMessageService.isValid) {
       return;


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

https://github.com/guardian/editions-card-builder/pull/58 take 2 but a smaller surface area as it doesn't change all the types.

Introduces [grid-client](https://github.com/guardian/grid-client) to this project (the first project to use this library 🎉 ).

The grid-client library provides some abstractions around handling a post message response from Grid, most notably it will validate the message and provides a [function to get the highest quality asset](https://github.com/guardian/grid-client/blob/241f9464ac81684c2e7fd642a9d4270feca44a2c/src/services/crop.ts#L31) in a crop. This function is safer than the current implementation; currently, we're assuming a `master` crop exists, which Grid does not guarantee as the field is [optional](https://github.com/guardian/grid/blob/86731ccab339bd2a2756cb3f96cd3f0e4e1db6fb/common-lib/src/main/scala/com/gu/mediaservice/model/Crop.scala#L11).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Run the app locally, it should continue to work as this change is a no-op.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

no-op

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

n/a