### PR TITLE
Use grid customcrop query parameter when loading grid iframe

### DIFF
--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -29,7 +29,7 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
   return (
     <div className="card-builder-left">
       <form className="card-builder-form">
-        <ImageSelect updateImageUrl={imageUrl => update('imageUrl', imageUrl)} updateOriginalImageData={props.updateOriginalImageData} />
+        <ImageSelect device={props.furniture?.device} updateImageUrl={imageUrl => update('imageUrl', imageUrl)} updateOriginalImageData={props.updateOriginalImageData} />
 
         <Collapsible name="Headline">
           <label htmlFor="headline">Text</label>

--- a/src/components/image-select.tsx
+++ b/src/components/image-select.tsx
@@ -1,18 +1,20 @@
 /** @jsx jsx */
-import { jsx } from '@emotion/core'
-import * as React from 'react';
-import config from "../utils/config"
-import Modal from './modal';
-import {IframePostMessageService} from "@guardian/grid-client"
+import { jsx } from "@emotion/core";
+import * as React from "react";
+import config from "../utils/config";
+import Modal from "./modal";
+import { IframePostMessageService } from "@guardian/grid-client";
+import { Device } from "../enums/device";
 
 interface GridModalProps {
-  updateImageUrl: (imageUrl: string) => void
-  updateOriginalImageData: (imageData: object) => void
+  updateImageUrl: (imageUrl: string) => void;
+  updateOriginalImageData: (imageData: object) => void;
+  device?: Device;
 }
 
 interface GridModalState {
-  modalOpen: boolean
-  imageId: string
+  modalOpen: boolean;
+  imageId: string;
 }
 
 class ImageSelect extends React.Component<GridModalProps, GridModalState> {
@@ -68,25 +70,34 @@ class ImageSelect extends React.Component<GridModalProps, GridModalState> {
     this.props.updateOriginalImageData(event.data.image);
   };
 
-  getIframeUrl(){
+  getGridQueryString() {
+    const { cropWidth, cropHeight, label } = config.crop[
+      this.props.device || "mobile"
+    ];
+    return `?cropType=${label}&customRatio=${label},${cropWidth},${cropHeight}`;
+  }
+
+  getIframeUrl() {
+    const queryString = this.getGridQueryString();
     return this.state.imageId
-      ? `${this.getGridUrl()}/images/${this.state.imageId}`
-      : this.getGridUrl();
+      ? `${this.getGridUrl()}/images/${this.state.imageId}${queryString}`
+      : `${this.getGridUrl()}${queryString}`;
   }
 
   getGridUrl() {
-    return`https://${config.gridDomain}`;
+    return `https://${config.gridDomain}`;
   }
 
   render() {
-    return(
+    return (
       <div>
-        <button type="button" className="image-select" onClick={this.openModal}>Select image</button>
+        <button type="button" className="image-select" onClick={this.openModal}>
+          Select image
+        </button>
 
         <Modal isOpen={this.state.modalOpen} dismiss={this.closeModal}>
-          <iframe css={{border: 'none'}} src={this.getIframeUrl()} />
+          <iframe css={{ border: "none" }} src={this.getIframeUrl()} />
         </Modal>
-
       </div>
     );
   }

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -18,8 +18,17 @@ class CanvasCard {
     this.drawing = false;
   }
 
-  private _getCanvasDimensions({ deviceWidth, deviceHeight, imageWidth, imageHeight }:
-     { deviceWidth: number, deviceHeight: number, imageWidth: number, imageHeight: number }) {
+  private _getCanvasDimensions({
+    deviceWidth,
+    deviceHeight,
+    imageWidth,
+    imageHeight
+  }: {
+    deviceWidth: number;
+    deviceHeight: number;
+    imageWidth: number;
+    imageHeight: number;
+  }) {
     //For each unit of width, the image has this height
     const deviceRatio = deviceWidth / deviceHeight;
     const imageRatio = imageWidth / imageHeight;
@@ -290,33 +299,32 @@ class CanvasCard {
 
     this.drawing = true;
 
-    return this._getImage(furniture.imageUrl).then(image => {
-      if(!this.furniture){
-        return Promise.reject();
-      }
+    return this._getImage(furniture.imageUrl)
+      .then(image => {
+        if (!this.furniture) {
+          return Promise.reject();
+        }
 
-      const [deviceWidth, deviceHeight] = Config.dimensions[this.furniture.device];
+        const { cropWidth, cropHeight } = Config.crop[this.furniture.device];
 
-      const { width, height, scale } = this._getCanvasDimensions({
-        deviceWidth,
-        deviceHeight,
-        imageHeight: image.height,
-        imageWidth: image.width
-      });
+        const { width, height, scale } = this._getCanvasDimensions({
+          deviceWidth: cropWidth,
+          deviceHeight: cropHeight,
+          imageHeight: image.height,
+          imageWidth: image.width
+        });
 
-      canvas.width = width;
-      canvas.height = height;
+        canvas.width = width;
+        canvas.height = height;
 
-      const canvasContext = canvas.getContext("2d");
+        const canvasContext = canvas.getContext("2d");
 
-      if(canvasContext){
-        this._drawImage({ canvasContext, image });
-        this._drawFurniture(canvas, canvasContext, this.furniture, scale)
-      }
-    })
-    .finally(
-      () => this.drawing = false
-    );
+        if (canvasContext) {
+          this._drawImage({ canvasContext, image });
+          this._drawFurniture(canvas, canvasContext, this.furniture, scale);
+        }
+      })
+      .finally(() => (this.drawing = false));
   }
 }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,21 +1,40 @@
-import { labs, lifestyle, culture, sport, opinion, news, brand, brandAlt, neutral, specialReport } from '@guardian/src-foundations/palette'
+import {
+  labs,
+  lifestyle,
+  culture,
+  sport,
+  opinion,
+  news,
+  brand,
+  brandAlt,
+  neutral,
+  specialReport
+} from "@guardian/src-foundations/palette";
 
 document.fonts.load("52px Guardian Headline Light");
 document.fonts.load("700 28px Guardian Text Egyptian");
 
-const DARK = 300
-const MAIN = 400
-const BRIGHT = 500
-const PASTEL = 600
-const FADED = 800
+const DARK = 300;
+const MAIN = 400;
+const BRIGHT = 500;
+const PASTEL = 600;
+const FADED = 800;
 const headlineLineHeightMultiplier = 1.05;
 const standfirstLineHeightMultiplier = 1.1;
 
 export default {
   gridDomain: process.env.GRID_DOMAIN as string,
-  dimensions: {
-    mobile: [525, 810],
-    tablet: [975, 1088]
+  crop: {
+    mobile: {
+      cropWidth: 525,
+      cropHeight: 810,
+      label: "mobile cover card"
+    },
+    tablet: {
+      cropWidth: 975,
+      cropHeight: 1088,
+      label: "tablet cover card"
+    }
   },
   padding: 10,
   headline: {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This PR adds a query string to the grid iframe url which makes use of the [custom crop functionality now available in the grid](https://github.com/guardian/grid/pull/3017). This will allow the production team to see exactly what crop they're going to get when selecting images.

The longer term motivation for this work is that we might start needing much taller crops for mobile cover cards, so we want to make users aware of the awkward aspect ratio these might have. This PR does not introduce any aspect ratio changes.

The ratios are a bit crazy right now - e.g. 525:810 - due to the way that the cover card tool currently works out dimensions. I think this could be simplified but wanted to keep as few moving parts as possible for this PR.


<img width="1390" alt="Screenshot 2020-10-02 at 17 40 46" src="https://user-images.githubusercontent.com/3606555/94948059-9c7ecc00-04d6-11eb-847f-a21c737bfe3e.png">


<img width="1392" alt="Screenshot 2020-10-02 at 17 41 14" src="https://user-images.githubusercontent.com/3606555/94948010-83761b00-04d6-11eb-84cf-a0c8d7bf8068.png">

I've had a struggle with prettier on this PR, if anyone has any advice please let me know, `npm run format` seems to only target js files, and when I changed it to support ts files as well it made changes in a million files unrelated to my change...so sorry about all the whitespace changes!

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Click the 'select image' button, choose an image from the grid, click' crop' and there should be a fixed crop size as per the screenshots above.


## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Happy production team.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
