### PR TITLE
Remove Grid query string

### DIFF
--- a/src/components/image-select.tsx
+++ b/src/components/image-select.tsx
@@ -78,7 +78,7 @@ class ImageSelect extends React.Component<GridModalProps, GridModalState> {
   }
 
   getIframeUrl() {
-    const queryString = this.getGridQueryString();
+    const queryString = ''; // TODO: query string removed in rushed friday afternoon fix
     return this.state.imageId
       ? `${this.getGridUrl()}/images/${this.state.imageId}${queryString}`
       : `${this.getGridUrl()}${queryString}`;

--- a/src/components/image-select.tsx
+++ b/src/components/image-select.tsx
@@ -78,7 +78,9 @@ class ImageSelect extends React.Component<GridModalProps, GridModalState> {
   }
 
   getIframeUrl() {
-    const queryString = ''; // TODO: query string removed in rushed friday afternoon fix
+    // TODO: query string removed in rushed friday afternoon fix
+    // suspected to be related to https://github.com/guardian/editions-card-builder/pull/86
+    const queryString = '';
     return this.state.imageId
       ? `${this.getGridUrl()}/images/${this.state.imageId}${queryString}`
       : `${this.getGridUrl()}${queryString}`;


### PR DESCRIPTION
This reverts the change in https://github.com/guardian/editions-card-builder/pull/86 with as few code changes as possible...I thought this would be nicer to review on a friday afternoon than a full PR revert. 

I'm not sure what's going on here as https://github.com/guardian/editions-card-builder/pull/86 was rolled out a while ago and the cover card builder's been in regular use since then but all of a sudden people are seeing their crops disappear. I'm hoping this change will resolve that problem.

Steps to reproduce:
 - select image - grid opens in iframe
 - perform a crop
 - at this point you should be taken back to the cover card builder and the crop should be imported. instead you are taken back to the grid