### PR TITLE
remove @guadian/grid-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -938,18 +938,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
-    "@guardian/grid-client": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@guardian/grid-client/-/grid-client-1.1.1.tgz",
-      "integrity": "sha512-pNZhe1/9mwvOqkcT5yOYTZdrXY+qgoEfjjl6ixw13020MOXmO9LoSDnJVqSjpfN9DH/WhpJ82pxLCIq6i5xEhQ==",
-      "requires": {
-        "fp-ts": "^2.8.2",
-        "io-ts": "^2.2.10",
-        "io-ts-types": "^0.5.10",
-        "monocle-ts": "^2.3.3",
-        "newtype-ts": "^0.3.4"
-      }
-    },
     "@guardian/src-foundations": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@guardian/src-foundations/-/src-foundations-1.7.0.tgz",
@@ -3329,11 +3317,6 @@
         "mime-types": "^2.1.12"
       }
     },
-    "fp-ts": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.8.2.tgz",
-      "integrity": "sha512-YKLBW75Rp+L9DuY1jr7QO6mZLTmJjy7tOqSAMcB2q2kBomqLjBMyV7dotpcnZmUYY6khMsfgYWtPbUDOFcNmkA=="
-    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -4378,16 +4361,6 @@
         "loose-envify": "^1.0.0"
       }
     },
-    "io-ts": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.10.tgz",
-      "integrity": "sha512-WHx5jJe7hPpc6JoSIVbD+Xn6tYqe3cRvNpX24d8Wi15/kxhRWa8apo0Gzag6Xg99sCNY9OHKylw/Vhv0JAbNPQ=="
-    },
-    "io-ts-types": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.11.tgz",
-      "integrity": "sha512-BqWYAvcSOxnKWIAYAcqF6nS+zhWRb6W+oezF2FzFt8+5a6b8PHNXmbOiV3MwRDY1G6FIctMo71QtIrExLT7LCQ=="
-    },
     "is-absolute-url": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
@@ -5085,11 +5058,6 @@
         }
       }
     },
-    "monocle-ts": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/monocle-ts/-/monocle-ts-2.3.3.tgz",
-      "integrity": "sha512-pcQyauWO2vapxyZgbhTd73Dv8TmTELx1rL81bvrtPO2sUYTi1MIHmw3j/iMyeNaJwTmnGNAjqJpYV8Gq1Eu68g=="
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -5121,11 +5089,6 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
-    },
-    "newtype-ts": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/newtype-ts/-/newtype-ts-0.3.4.tgz",
-      "integrity": "sha512-lFJnWAt0oXX1j1ErNy9RU5+FPNtVyzugHW2MchaaMiOeeS9LEmqAAOqyHPFQ0Uw895jStSYGSCslrByzYxFJYQ=="
     },
     "nice-try": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "homepage": "https://github.com/guardian/editions-card-builder#readme",
   "dependencies": {
     "@emotion/core": "^10.0.34",
-    "@guardian/grid-client": "^1.1.1",
     "@guardian/src-foundations": "^1.5.0",
     "@types/css-font-loading-module": "0.0.4",
     "@types/debounce": "^1.2.0",

--- a/src/components/image-select.tsx
+++ b/src/components/image-select.tsx
@@ -3,7 +3,6 @@ import { jsx } from "@emotion/core";
 import * as React from "react";
 import config from "../utils/config";
 import Modal from "./modal";
-import { IframePostMessageService } from "@guardian/grid-client";
 import { Device } from "../enums/device";
 
 interface GridModalProps {
@@ -53,20 +52,24 @@ class ImageSelect extends React.Component<GridModalProps, GridModalState> {
       return;
     }
 
-    const postMessageService = new IframePostMessageService(event)
+    const data = event.data;
 
-    if(!postMessageService.isValid) {
+    if(!data) {
       return;
     }
 
-    const imageUrl: URL = postMessageService.highestQualityImageURL!;
+    if(!this.validMessage(data)) {
+      return;
+    }
+
+    const imageUrl = event.data.crop.data.master.secureUrl;
 
     this.setState({
-      imageId: postMessageService.imageId!
+      imageId: event.data.image.data.id as string
     });
 
     this.closeModal();
-    this.props.updateImageUrl(imageUrl.toString());
+    this.props.updateImageUrl(imageUrl);
     this.props.updateOriginalImageData(event.data.image);
   };
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

It appears the grid-client library doesn't work for every possible shape of data Grid responds with. Removing it for the time being.

Related to https://github.com/guardian/editions-card-builder/pull/85.
