### PR TITLE
Revert "Remove Grid query string"

### DIFF
--- a/src/components/image-select.tsx
+++ b/src/components/image-select.tsx
@@ -78,9 +78,7 @@ class ImageSelect extends React.Component<GridModalProps, GridModalState> {
   }
 
   getIframeUrl() {
-    // TODO: query string removed in rushed friday afternoon fix
-    // suspected to be related to https://github.com/guardian/editions-card-builder/pull/86
-    const queryString = '';
+    const queryString = this.getGridQueryString();
     return this.state.imageId
       ? `${this.getGridUrl()}/images/${this.state.imageId}${queryString}`
       : `${this.getGridUrl()}${queryString}`;


### PR DESCRIPTION
Reverts guardian/editions-card-builder#87 as it looks like the error discussed there was actually caused by https://github.com/guardian/editions-card-builder/pull/85 