### PR TITLE
Revert "remove @guadian/grid-client"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -938,6 +938,18 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
+    "@guardian/grid-client": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@guardian/grid-client/-/grid-client-1.1.1.tgz",
+      "integrity": "sha512-pNZhe1/9mwvOqkcT5yOYTZdrXY+qgoEfjjl6ixw13020MOXmO9LoSDnJVqSjpfN9DH/WhpJ82pxLCIq6i5xEhQ==",
+      "requires": {
+        "fp-ts": "^2.8.2",
+        "io-ts": "^2.2.10",
+        "io-ts-types": "^0.5.10",
+        "monocle-ts": "^2.3.3",
+        "newtype-ts": "^0.3.4"
+      }
+    },
     "@guardian/src-foundations": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@guardian/src-foundations/-/src-foundations-1.7.0.tgz",
@@ -3317,6 +3329,11 @@
         "mime-types": "^2.1.12"
       }
     },
+    "fp-ts": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.8.2.tgz",
+      "integrity": "sha512-YKLBW75Rp+L9DuY1jr7QO6mZLTmJjy7tOqSAMcB2q2kBomqLjBMyV7dotpcnZmUYY6khMsfgYWtPbUDOFcNmkA=="
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -4361,6 +4378,16 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "io-ts": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.10.tgz",
+      "integrity": "sha512-WHx5jJe7hPpc6JoSIVbD+Xn6tYqe3cRvNpX24d8Wi15/kxhRWa8apo0Gzag6Xg99sCNY9OHKylw/Vhv0JAbNPQ=="
+    },
+    "io-ts-types": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.11.tgz",
+      "integrity": "sha512-BqWYAvcSOxnKWIAYAcqF6nS+zhWRb6W+oezF2FzFt8+5a6b8PHNXmbOiV3MwRDY1G6FIctMo71QtIrExLT7LCQ=="
+    },
     "is-absolute-url": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
@@ -5058,6 +5085,11 @@
         }
       }
     },
+    "monocle-ts": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/monocle-ts/-/monocle-ts-2.3.3.tgz",
+      "integrity": "sha512-pcQyauWO2vapxyZgbhTd73Dv8TmTELx1rL81bvrtPO2sUYTi1MIHmw3j/iMyeNaJwTmnGNAjqJpYV8Gq1Eu68g=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -5089,6 +5121,11 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
+    },
+    "newtype-ts": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/newtype-ts/-/newtype-ts-0.3.4.tgz",
+      "integrity": "sha512-lFJnWAt0oXX1j1ErNy9RU5+FPNtVyzugHW2MchaaMiOeeS9LEmqAAOqyHPFQ0Uw895jStSYGSCslrByzYxFJYQ=="
     },
     "nice-try": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/guardian/editions-card-builder#readme",
   "dependencies": {
     "@emotion/core": "^10.0.34",
+    "@guardian/grid-client": "^1.1.1",
     "@guardian/src-foundations": "^1.5.0",
     "@types/css-font-loading-module": "0.0.4",
     "@types/debounce": "^1.2.0",

--- a/src/components/image-select.tsx
+++ b/src/components/image-select.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import config from "../utils/config";
 import Modal from "./modal";
 import { IframePostMessageService } from "@guardian/grid-client";
+import { Reporter } from "@guardian/grid-client/lib/utils"
 import { Device } from "../enums/device";
 
 interface GridModalProps {
@@ -53,7 +54,7 @@ class ImageSelect extends React.Component<GridModalProps, GridModalState> {
       return;
     }
 
-    const postMessageService = new IframePostMessageService(event)
+    const postMessageService = new IframePostMessageService(event, Reporter.default)
 
     if(!postMessageService.isValid) {
       return;

--- a/src/components/image-select.tsx
+++ b/src/components/image-select.tsx
@@ -3,6 +3,7 @@ import { jsx } from "@emotion/core";
 import * as React from "react";
 import config from "../utils/config";
 import Modal from "./modal";
+import { IframePostMessageService } from "@guardian/grid-client";
 import { Device } from "../enums/device";
 
 interface GridModalProps {
@@ -52,24 +53,20 @@ class ImageSelect extends React.Component<GridModalProps, GridModalState> {
       return;
     }
 
-    const data = event.data;
+    const postMessageService = new IframePostMessageService(event)
 
-    if(!data) {
+    if(!postMessageService.isValid) {
       return;
     }
 
-    if(!this.validMessage(data)) {
-      return;
-    }
-
-    const imageUrl = event.data.crop.data.master.secureUrl;
+    const imageUrl: URL = postMessageService.highestQualityImageURL!;
 
     this.setState({
-      imageId: event.data.image.data.id as string
+      imageId: postMessageService.imageId!
     });
 
     this.closeModal();
-    this.props.updateImageUrl(imageUrl);
+    this.props.updateImageUrl(imageUrl.toString());
     this.props.updateOriginalImageData(event.data.image);
   };
 


### PR DESCRIPTION
Reverts guardian/editions-card-builder#88.

Re-introducing `grid-client`. We experienced an issue where this tool could not parse and validate the payload coming from Grid. This was related to Grid sending erroneous data; this is fixed in https://github.com/guardian/grid/pull/3033.

This also re-introduces the [reporter](https://github.com/guardian/grid-client/blob/41b82ab1e0dd9d6836e0812502878b40ffa83ecc/src/utils/reporter.ts) (a wrapper around [`PathReporter`](https://github.com/gcanti/io-ts/blob/46999babe78b08765a573a1a56d5c16233d99f0b/index.md#error-reporters)), which will console [log a detailed message](https://github.com/guardian/grid-client/blob/41b82ab1e0dd9d6836e0812502878b40ffa83ecc/src/services/iframe-post-message.ts#L23) should the Grid payload fail to validate again in the future to make debugging issues that much easier.