### PR TITLE
Add safe area overlay on image. 

### DIFF
--- a/src/components/image-select.tsx
+++ b/src/components/image-select.tsx
@@ -72,10 +72,8 @@ class ImageSelect extends React.Component<GridModalProps, GridModalState> {
   };
 
   getGridQueryString() {
-    const { cropWidth, cropHeight, label } = config.crop[
-      this.props.device || "mobile"
-    ];
-    return `?cropType=${label}&customRatio=${label},${cropWidth},${cropHeight}`;
+    const { cropRatio, label } = config.crop[this.props.device || "mobile"];
+    return `?cropType=${label}&customRatio=${label},10,${cropRatio * 10}`;
   }
 
   getIframeUrl() {

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -335,7 +335,6 @@ class CanvasCard {
           this._drawImage({ canvasContext, image });
           this._drawFurniture(canvas, canvasContext, this.furniture, scale);
           this._drawUnsafearea(canvasContext, width, height, safeRatio, cropRatio);
-
         }
       })
       .finally(() => (this.drawing = false));

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -283,6 +283,29 @@ class CanvasCard {
     );
   }
 
+  // this code has been shamelessly lifted from https://stackoverflow.com/a/32206237
+  private crossHatchPattern(canvasContext: CanvasRenderingContext2D) {
+    const pattern = document.createElement("canvas")
+    pattern.width=32;
+    pattern.height=16;
+    const patternCtx= pattern.getContext('2d');
+
+    const [x0, x1, y0, y1, offset] = [36, -4, -2, 18, 32];
+    if (patternCtx) {
+      patternCtx.strokeStyle = "rgba(255,0,0,0.5)";
+      patternCtx.lineWidth=2;
+      patternCtx.beginPath();
+      patternCtx.moveTo(x0,y0);
+      patternCtx.lineTo(x1,y1);
+      patternCtx.moveTo(x0-offset,y0);
+      patternCtx.lineTo(x1-offset,y1);
+      patternCtx.moveTo(x0+offset,y0);
+      patternCtx.lineTo(x1+offset,y1);
+      patternCtx.stroke();
+      return canvasContext.createPattern(pattern,'repeat');
+  }
+}
+
   private _drawUnsafearea(
     canvasContext: CanvasRenderingContext2D,
     width: number,
@@ -292,9 +315,14 @@ class CanvasCard {
   ) {
     const safeAreaProportion = safeRatio / cropRatio;
     const unsafeAreaY = Math.floor(height * safeAreaProportion);
-    canvasContext.fillStyle = "rgba(255,255,255,0.5)";
-    canvasContext.fillRect(0, unsafeAreaY, width, height - unsafeAreaY);
-  };
+    const pattern = this.crossHatchPattern(canvasContext);
+
+    if (pattern) {
+      canvasContext.fillStyle=pattern;
+      canvasContext.fillRect(0, unsafeAreaY, width, height - unsafeAreaY);
+    }
+  }
+
 
   draw(canvas: HTMLCanvasElement, furniture: Furniture) {
     if (!furniture.imageUrl) {

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -284,7 +284,7 @@ class CanvasCard {
   }
 
   private _drawUnsafearea(
-    canvasContext: CanvasRenderingContext2D,,
+    canvasContext: CanvasRenderingContext2D,
     width: number,
     height: number,
     safeRatio: number,

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -293,7 +293,7 @@ class CanvasCard {
     const [x0, x1, y0, y1, offset] = [36, -4, -2, 18, 32];
     if (patternCtx) {
       patternCtx.strokeStyle = "rgba(255,0,0,0.5)";
-      patternCtx.lineWidth=2;
+      patternCtx.lineWidth=5;
       patternCtx.beginPath();
       patternCtx.moveTo(x0,y0);
       patternCtx.lineTo(x1,y1);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -28,11 +28,15 @@ export default {
     mobile: {
       cropWidth: 525,
       cropHeight: 810,
+      safeRatio: 1.3,
+      cropRatio: 1.6,
       label: "mobile cover card"
     },
     tablet: {
       cropWidth: 975,
       cropHeight: 1088,
+      cropRatio: 1.1,
+      safeRatio: 1.1,
       label: "tablet cover card"
     }
   },


### PR DESCRIPTION
## What does this change?
This PR introduces 2 new config properties - 'cropRatio' and 'safeRatio'. `cropRatio` is what you have to multiply the width by to get the height of the card. `safeRatio` is the area of the image that is 'guaranteed' to appear on the majority of devices - it's currently based off one of the monster wide iphones. 

Using these properties, an  extra transparent rectange is drawn on the canvas showing the area of the image that might be cropped off on certain devices. It's a white 50% opacity box at the moment but I'm open to suggestions for improvements...

As part of this I've removed `cropHeight` as this can be calculated from the ratio. This is a further step towards not having absolute width/height in the cover card tool (they're irrelevant - we only care about aspect ratios).

NOTE: To keep the ratios to 1 decimal place I've rounded them up/down so this *will result in slightly different crop sizes* - hopefully negligible I will make sure this gets properly tested before the production shifts begin.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
The box will be visible on all mobile cards so just give it a try!

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
It should be more obvious to the production teams which bits of the image might be chopped off

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

The box could be really annoying - I will run the screenshots below past  Katy to see what she things.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<img width="300" alt="Screenshot 2020-10-15 at 14 58 46" src="https://user-images.githubusercontent.com/3606555/96139638-f3cd6500-0ef6-11eb-870e-8ef21e214016.png">
<img width="250" alt="Screenshot 2020-10-15 at 14 57 41" src="https://user-images.githubusercontent.com/3606555/96139693-0051bd80-0ef7-11eb-889d-6e330d42c5af.png">


## Relevant GIF
![safety first](https://media2.giphy.com/media/dXtmDMiltXTJXBxqVQ/giphy.gif)