### PR TITLE
Disable safe area feature pending accessibility improvements.

### DIFF
--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -367,7 +367,8 @@ class CanvasCard {
           this._drawFurniture(canvas, canvasContext, this.furniture, scale);
         }
         if (canvasOverlayContext){
-          this._drawUnsafearea(canvasOverlayContext, width, height, safeRatio, cropRatio);
+          // feature disabled till it can be made more accessible
+          // this._drawUnsafearea(canvasOverlayContext, width, height, safeRatio, cropRatio);
         }
       })
       .finally(() => (this.drawing = false));


### PR DESCRIPTION
I tested the safe area feature with Katy V this morning and she suggested rolling the safe area feature added in https://github.com/guardian/editions-card-builder/pull/93 back until it can be made more accessible - mainly so that it works on images that are red! It's going to take me a while to get my head round how to do that and she'd rather not have to update the style guide twice with an in flux feature so I said I'd remove this for now so as not to confuse people. I'd prefer not to revert the whole feature as that's already been through code review here https://github.com/guardian/editions-card-builder/pull/93 - there should be a fix for it wiithiin the next couple of days... 

I think this back and forth is another case for allowing testing of dev branches on master as discussed here https://github.com/guardian/editions-card-builder/pull/83