### PR TITLE
Replace reference to master with main in config

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: CD
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this change?
Replaces reference to 'master' in CD config file. Once this is merged, it will test whether the master-to-main replacement was successful.