### PR TITLE
Re-Enable unsafe area with different coloured stripes

### DIFF
--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -229,6 +229,9 @@ export default (props: {furniture?: Furniture, updateFurniture: (newFurniture: F
           </fieldset>
         </Collapsible>
     </form>
+    <div>
+      <p>Note: Shaded/striped section of image is likely to be cropped on wider screen devices</p>
+    </div>
     </div>
   )
 }

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -286,21 +286,20 @@ class CanvasCard {
   // this code has been shamelessly lifted from https://stackoverflow.com/a/32206237
   private crossHatchPattern(canvasContext: CanvasRenderingContext2D) {
     const pattern = document.createElement("canvas")
-    pattern.width=32;
-    pattern.height=16;
-    const patternCtx= pattern.getContext('2d');
+    pattern.width = 100;
+    pattern.height = 20;
+    const patternCtx = pattern.getContext('2d');
 
-    const [x0, x1, y0, y1, offset] = [36, -4, -2, 18, 32];
     if (patternCtx) {
-      patternCtx.strokeStyle = "rgba(255,0,0,0.5)";
-      patternCtx.lineWidth=5;
       patternCtx.beginPath();
-      patternCtx.moveTo(x0,y0);
-      patternCtx.lineTo(x1,y1);
-      patternCtx.moveTo(x0-offset,y0);
-      patternCtx.lineTo(x1-offset,y1);
-      patternCtx.moveTo(x0+offset,y0);
-      patternCtx.lineTo(x1+offset,y1);
+      patternCtx.strokeStyle = "rgba(255,0,0,0.5)";
+      patternCtx.lineWidth = pattern.height
+      patternCtx.moveTo(0 ,0);
+      patternCtx.lineTo(pattern.width, 0);
+      patternCtx.stroke();
+      patternCtx.strokeStyle = "rgba(255,255,255,0.5)";
+      patternCtx.moveTo(0 ,pattern.height / 2);
+      patternCtx.lineTo(pattern.width, pattern.height / 2);
       patternCtx.stroke();
       return canvasContext.createPattern(pattern,'repeat');
   }
@@ -367,8 +366,7 @@ class CanvasCard {
           this._drawFurniture(canvas, canvasContext, this.furniture, scale);
         }
         if (canvasOverlayContext){
-          // feature disabled till it can be made more accessible
-          // this._drawUnsafearea(canvasOverlayContext, width, height, safeRatio, cropRatio);
+          this._drawUnsafearea(canvasOverlayContext, width, height, safeRatio, cropRatio);
         }
       })
       .finally(() => (this.drawing = false));


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This is another (hopefully final stab) at the work discussed in https://github.com/guardian/editions-card-builder/pull/91- which aims to make it clearer to users which bit of the image could get cropped off on wider screen devices.

The changes introduced here change the 'unsafe area' pattern so that it is striped in red and white, which should mean it is visible over all images (even red ones). I wasn't smart enough to red/white diagonal stripes so they're also now horizontal!

As part of this change I've also added some instructions explaining what the safe area is on the left sidebar - Katy thought it might be useful to have something so it's not a suprise.

It looks like this:
<img width="498" alt="Screenshot 2020-10-22 at 10 48 40" src="https://user-images.githubusercontent.com/3606555/96901408-1e856380-148b-11eb-9a75-e3a94294eef8.png">

The instructions look like this:
<img width="439" alt="Screenshot 2020-10-22 at 17 23 11" src="https://user-images.githubusercontent.com/3606555/96901539-5096c580-148b-11eb-847b-312058d8d365.png">


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Add an image to the card builder in mobile mode - you should see the stripes.
