### PR TITLE
Allow full width text on cover cards.

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -22,19 +22,21 @@ const FADED = 800;
 const headlineLineHeightMultiplier = 1.05;
 const standfirstLineHeightMultiplier = 1.1;
 
+const MOBILE_CROP_WIDTH = 525
+const TABLET_CROP_WIDTH = 975
+const TEXT_MARGIN = 25
+
 export default {
   gridDomain: process.env.GRID_DOMAIN as string,
   crop: {
     mobile: {
-      cropWidth: 525,
-      cropHeight: 810,
+      cropWidth: MOBILE_CROP_WIDTH,
       safeRatio: 1.3,
       cropRatio: 1.6,
       label: "mobile cover card"
     },
     tablet: {
-      cropWidth: 975,
-      cropHeight: 1088,
+      cropWidth: TABLET_CROP_WIDTH,
       cropRatio: 1.1,
       safeRatio: 1.1,
       label: "tablet cover card"
@@ -44,7 +46,7 @@ export default {
   headline: {
     font: "Guardian Titlepiece",
     mobile: {
-      maxWidth: 420,
+      maxWidth: MOBILE_CROP_WIDTH - TEXT_MARGIN,
       lineHeight: {
         small: 52 * headlineLineHeightMultiplier,
         medium: 68 * headlineLineHeightMultiplier,
@@ -59,7 +61,7 @@ export default {
       }
     },
     tablet: {
-      maxWidth: 648,
+      maxWidth: TABLET_CROP_WIDTH - TEXT_MARGIN,
       lineHeight: {
         small: 80 * headlineLineHeightMultiplier,
         medium: 105 * headlineLineHeightMultiplier,
@@ -77,7 +79,7 @@ export default {
   standfirst: {
     font: "Guardian Text Egyptian",
     mobile: {
-      maxWidth: 350,
+      maxWidth: MOBILE_CROP_WIDTH - TEXT_MARGIN,
       lineHeight: {
         small: 28 * standfirstLineHeightMultiplier,
         medium: 32 * standfirstLineHeightMultiplier
@@ -88,7 +90,7 @@ export default {
       }
     },
     tablet: {
-      maxWidth: 572,
+      maxWidth: TABLET_CROP_WIDTH - TEXT_MARGIN,
       lineHeight: {
         small: 43 * standfirstLineHeightMultiplier,
         medium: 49 * standfirstLineHeightMultiplier


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
The production team have been asking for a while for it to be possible for cover card text to use the full width. In the app we only crop from the bottom upwards, so this seems a sensible change to make.

Before:
<img width="300" alt="Screenshot 2020-10-23 at 10 49 49" src="https://user-images.githubusercontent.com/3606555/96989549-c3508100-151d-11eb-8c2e-9baa1b7395c9.png">

After:
<img width="300" alt="Screenshot 2020-10-23 at 10 39 41" src="https://user-images.githubusercontent.com/3606555/96988547-60121f00-151c-11eb-8052-6ab8c47434e8.png">

<img width="300" alt="Screenshot 2020-10-23 at 10 40 50" src="https://user-images.githubusercontent.com/3606555/96988518-58eb1100-151c-11eb-81bb-ffa7069aabce.png">


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run cover card tool, check that text can span the full width but doesn't run off the edge


## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Happy production team, no text cropped!

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
The main risk would be if the app decides to start cropping from the sides, but that would affect a lot of other stuff too so I think we're safe.
## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
