### PR TITLE
Bump mobile crop ratio to 1.7

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -32,7 +32,7 @@ export default {
     mobile: {
       cropWidth: MOBILE_CROP_WIDTH,
       safeRatio: 1.3,
-      cropRatio: 1.6,
+      cropRatio: 1.7,
       label: "mobile cover card"
     },
     tablet: {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This changes the aspect ratio of mobile cover cards, making them taller so that they don't have such a large border on iPhone SE.

This has been attempted before, but the hope is that following from the safe area introduced in https://github.com/guardian/editions-card-builder/pull/77 and the grid crop guide introduced here https://github.com/guardian/editions-card-builder/pull/86 this is now a viable ratio for the production team to use. 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Developers: run the tool, observe the 'taller' crop ratio

This feature is likely to need rolling back - the plan is:
 - Arrange a time for Katy to test this
 - Merge to PROD
 - Ask Katy and her team to test
 - no good - revert, merge revert

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Less whitespace in the editions app
## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
See above - this ratio might be unworkable.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
