### PR TITLE
Add safe area to tablet cards

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -38,7 +38,7 @@ export default {
     tablet: {
       cropWidth: TABLET_CROP_WIDTH,
       cropRatio: 1.1,
-      safeRatio: 1.1,
+      safeRatio: 1.0,
       label: "tablet cover card"
     }
   },


### PR DESCRIPTION
## What does this change?
Introduces a 'safe area' for tablets. I worked this out by taking a screenshot of a cover card on an ipad pro 12.9 inch, which I think is the biggest. I then worked out what percentage of the image got cropped and applied the same thing in reverse to another cover card to check that it correctly calculated the safe area.

For full details of the safe area feature see https://github.com/guardian/editions-card-builder/pull/91

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Deploy, check that a safe area appears on tablet images. 

## How can we measure success?
Happy production team able to relax about tablet images

## Have we considered potential risks?
The safe area could be wrong, in which case cover cards could end up with an unexpected crop off the bottom which could cut through essential bits of the image. I'd argue this would still be an improvement though.

## Images
Original cover card:
![Screenshot 2020-11-23 at 17 15 30](https://user-images.githubusercontent.com/3606555/99995159-e76be000-2db1-11eb-9fec-44d52356c136.png)
What users see on an iPad Pro:
![Screenshot 2020-11-23 at 17 14 34](https://user-images.githubusercontent.com/3606555/99995155-e5098600-2db1-11eb-82d1-5548e3e5adbb.png)

