### PR TITLE
Make tablet headline font display the same size as mobile

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -19,26 +19,44 @@ const MAIN = 400;
 const BRIGHT = 500;
 const PASTEL = 600;
 const FADED = 800;
-const headlineLineHeightMultiplier = 1.05;
-const standfirstLineHeightMultiplier = 1.1;
 
-const MOBILE_CROP_WIDTH = 525
-const TABLET_CROP_WIDTH = 975
-const TEXT_MARGIN = 25
+const HEADLINE_LINE_HEIGHT_MULTIPLIER = 1.05;
+const STANDFIRST_LINE_HEIGHT_MULTIPLIER = 1.1;
+
+const TEXT_MARGIN = 25;
+
+const MOBILE_CROP_WIDTH = 525;
+const TABLET_CROP_WIDTH = 975;
+
+const MOBILE_SAFE_RATIO = 1.3;
+const TABLET_SAFE_RATIO = 1.0;
+
+const MOBILE_CROP_RATIO = 1.7;
+const TABLET_CROP_RATIO = 1.1;
+
+const HEADLINE_FONT_SIZE_SMALL = 52;
+const HEADLINE_FONT_SIZE_MEDIUM = 68;
+const HEADLINE_FONT_SIZE_LARGE = 84;
+const HEADLINE_FONT_SIZE_XLARGE = 100;
+
+const scaleFontSizeForTablet = (fontSize: number) => {
+  // scale the tablet font size based on the device height ratio so the font size appears consistent between devices
+  return Math.floor(fontSize / ((MOBILE_CROP_WIDTH * MOBILE_CROP_RATIO) / (TABLET_CROP_WIDTH * TABLET_CROP_RATIO)))
+}
 
 export default {
   gridDomain: process.env.GRID_DOMAIN as string,
   crop: {
     mobile: {
       cropWidth: MOBILE_CROP_WIDTH,
-      safeRatio: 1.3,
-      cropRatio: 1.7,
+      safeRatio: MOBILE_SAFE_RATIO,
+      cropRatio: MOBILE_CROP_RATIO,
       label: "mobile cover card"
     },
     tablet: {
       cropWidth: TABLET_CROP_WIDTH,
-      cropRatio: 1.1,
-      safeRatio: 1.0,
+      safeRatio: TABLET_SAFE_RATIO,
+      cropRatio: TABLET_CROP_RATIO,
       label: "tablet cover card"
     }
   },
@@ -48,31 +66,31 @@ export default {
     mobile: {
       maxWidth: MOBILE_CROP_WIDTH - TEXT_MARGIN,
       lineHeight: {
-        small: 52 * headlineLineHeightMultiplier,
-        medium: 68 * headlineLineHeightMultiplier,
-        large: 84 * headlineLineHeightMultiplier,
-        xLarge: 100 * headlineLineHeightMultiplier
+        small: HEADLINE_FONT_SIZE_SMALL * HEADLINE_LINE_HEIGHT_MULTIPLIER,
+        medium: HEADLINE_FONT_SIZE_MEDIUM * HEADLINE_LINE_HEIGHT_MULTIPLIER,
+        large: HEADLINE_FONT_SIZE_LARGE * HEADLINE_LINE_HEIGHT_MULTIPLIER,
+        xLarge: HEADLINE_FONT_SIZE_XLARGE * HEADLINE_LINE_HEIGHT_MULTIPLIER
       },
       fontSize: {
-        small: 52,
-        medium: 68,
-        large: 84,
-        xLarge: 100
+        small: HEADLINE_FONT_SIZE_SMALL,
+        medium: HEADLINE_FONT_SIZE_MEDIUM,
+        large: HEADLINE_FONT_SIZE_LARGE,
+        xLarge: HEADLINE_FONT_SIZE_XLARGE
       }
     },
     tablet: {
       maxWidth: TABLET_CROP_WIDTH - TEXT_MARGIN,
       lineHeight: {
-        small: 80 * headlineLineHeightMultiplier,
-        medium: 105 * headlineLineHeightMultiplier,
-        large: 128 * headlineLineHeightMultiplier,
-        xLarge: 180 * headlineLineHeightMultiplier
+        small: scaleFontSizeForTablet(HEADLINE_FONT_SIZE_SMALL) * HEADLINE_LINE_HEIGHT_MULTIPLIER,
+        medium: scaleFontSizeForTablet(HEADLINE_FONT_SIZE_MEDIUM) * HEADLINE_LINE_HEIGHT_MULTIPLIER,
+        large: scaleFontSizeForTablet(HEADLINE_FONT_SIZE_LARGE) * HEADLINE_LINE_HEIGHT_MULTIPLIER,
+        xLarge: scaleFontSizeForTablet(HEADLINE_FONT_SIZE_XLARGE) * HEADLINE_LINE_HEIGHT_MULTIPLIER
       },
       fontSize: {
-        small: 80,
-        medium: 105,
-        large: 128,
-        xLarge: 180
+        small: scaleFontSizeForTablet(HEADLINE_FONT_SIZE_SMALL),
+        medium: scaleFontSizeForTablet(HEADLINE_FONT_SIZE_MEDIUM),
+        large: scaleFontSizeForTablet(HEADLINE_FONT_SIZE_LARGE),
+        xLarge: scaleFontSizeForTablet(HEADLINE_FONT_SIZE_XLARGE)
       }
     }
   },
@@ -81,8 +99,8 @@ export default {
     mobile: {
       maxWidth: MOBILE_CROP_WIDTH - TEXT_MARGIN,
       lineHeight: {
-        small: 28 * standfirstLineHeightMultiplier,
-        medium: 32 * standfirstLineHeightMultiplier
+        small: 28 * STANDFIRST_LINE_HEIGHT_MULTIPLIER,
+        medium: 32 * STANDFIRST_LINE_HEIGHT_MULTIPLIER
       },
       fontSize: {
         small: 28,
@@ -92,8 +110,8 @@ export default {
     tablet: {
       maxWidth: TABLET_CROP_WIDTH - TEXT_MARGIN,
       lineHeight: {
-        small: 43 * standfirstLineHeightMultiplier,
-        medium: 49 * standfirstLineHeightMultiplier
+        small: 43 * STANDFIRST_LINE_HEIGHT_MULTIPLIER,
+        medium: 49 * STANDFIRST_LINE_HEIGHT_MULTIPLIER
       },
       fontSize: {
         small: 43,


### PR DESCRIPTION
## What does this change?
This makes the headline font appear the same size on tablet cards as it does on mobile. This was requested by editorial, as having different font sizes between the mobile and tablet cards is creating layout issues.

Font size is initially set in config and then dynamically scaled based on device height and image resolution. In this PR, rather than setting the initial tablet font size as a hard-coded value we calculate it by taking the mobile headline font size and scale it by the device height ratio, like so:

```tablet_font_size = mobile_font_size / (mobile_device_height / tablet_device_height)```

This scales the tablet font size down to an appropriate amount, so it appears the same size when it is rendered.

## How to test
You can run the editions card builder locally by following the instructions on the readme and create a new card in the UI. When you toggle between devices in the left hand side menu you should see the image size change but the headline font size remain constant.
