### PR TITLE
Add permission to workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,8 @@ on:
       - main
 jobs:
   validate:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Paired on with @rhystmills.

Currently our deploys are [failing](https://github.com/guardian/editions-card-builder/actions/runs/9349575546/job/25731191433) due to an auth error:
```
> gh-pages -d dist -u "github-actions-bot <support+actions@github.com>"

remote: Permission to guardian/editions-card-builder.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/guardian/editions-card-builder.git/': The requested URL returned error: 403

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! editions-card-builder@1.0.0 deploy: `gh-pages -d dist -u "github-actions-bot <support+actions@github.com>"`
npm ERR! Exit status 1
```

Following the pattern outlined in https://github.com/tschaub/gh-pages/issues/429#issuecomment-1126987413, we are adding permissions to the workflow to hopefully fix this issue.