### PR TITLE
ensure CI runs on `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
+  push:
+    branches:
+      - main
 jobs:
   CI:
     runs-on: ubuntu-latest


### PR DESCRIPTION
noticed PRout was reporting overdue on https://github.com/guardian/editions-card-builder/pull/130 despite CD being configured in riff-raff... turns out CI action didn't run for main (which made sense when using gh-pages)