### PR TITLE
fix PRout (since move to `actions-static-site`)

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,5 +1,5 @@
 {
   "checkpoints": {
-    "PROD": { "url": "https://editions-card-builder.gutools.co.uk/build-info.json", "overdue": "10M" }
+    "PROD": { "url": "https://editions-card-builder.gutools.co.uk/_prout", "overdue": "10M" }
   }
 }

--- a/script/ci
+++ b/script/ci
@@ -6,6 +6,6 @@ npm install
 npm run clean
 npm run build
 
-# make current git commit hash available on /build-info.json for prout
+# make current git commit hash available on /_prout for prout
 COMMIT_ID=$(git rev-parse HEAD)
-echo "{\"gitCommitId\": \"$COMMIT_ID\"}" > dist/build-info.json
+echo "{\"gitCommitId\": \"$COMMIT_ID\"}" > dist/_prout


### PR DESCRIPTION
Noticed #132 was still showing `Overdue-on-PROD` label.

Since moving to `actions-static-site` PRout could no longer access `/build-info.json` (because Google auth by default) but fortunately (thanks to https://github.com/guardian/actions-static-site/pull/21) `**/_prout` paths skip auth, so renaming the file containing git hash and changed `.prout.json` to reference